### PR TITLE
fix(ci): release SBOM artifact named vet-, not ground-

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,18 +116,18 @@ jobs:
         with:
           path: .
           format: spdx-json
-          output-file: ground-${{ steps.version.outputs.VERSION }}.spdx.json
+          output-file: vet-${{ steps.version.outputs.VERSION }}.spdx.json
           upload-artifact: false
           upload-release-assets: false
 
       - name: Attest SBOM
         uses: actions/attest-sbom@v2
         with:
-          subject-path: ground-${{ steps.version.outputs.VERSION }}.spdx.json
-          sbom-path: ground-${{ steps.version.outputs.VERSION }}.spdx.json
+          subject-path: vet-${{ steps.version.outputs.VERSION }}.spdx.json
+          sbom-path: vet-${{ steps.version.outputs.VERSION }}.spdx.json
 
       - name: Upload SBOM to release
         uses: softprops/action-gh-release@v2
         with:
-          files: ground-${{ steps.version.outputs.VERSION }}.spdx.json
+          files: vet-${{ steps.version.outputs.VERSION }}.spdx.json
           fail_on_unmatched_files: true


### PR DESCRIPTION
The SBOM job in `release.yml` names its artifact `ground-${VERSION}.spdx.json` — a copy-paste residue from when the workflow was adapted from ground (same class as 62a3b8d, which fixed the build target from `./cmd/ground` to `./cmd/vet`).

Effect: the SBOM attached to vet releases is mislabeled with the wrong project name. Renamed all four references (`output-file`, `subject-path`, `sbom-path`, release `files`) to `vet-`.

No functional change beyond the filename; nothing consumes the old name.