### PR TITLE
feat(gate): produce the verdict through the provabl/evidence kernel (closes #7)

### DIFF
--- a/cmd/vet/main.go
+++ b/cmd/vet/main.go
@@ -114,9 +114,9 @@ Examples:
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runVerify(args[0], vetDir, verify.Options{
-				Source:        source,
-				MinSLSALevel:  minSLSA,
-				CheckCVEs:     checkCVEs,
+				Source:         source,
+				MinSLSALevel:   minSLSA,
+				CheckCVEs:      checkCVEs,
 				SigningIDRegex: signingID,
 			})
 		},
@@ -253,7 +253,7 @@ attest Cedar policy example:
 Run 'vet verify' before 'vet gate' to populate the verification record.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGate(args[0], vetDir, policyPath)
+			return runGate(cmd.Context(), args[0], vetDir, policyPath)
 		},
 	}
 	cmd.Flags().StringVar(&policyPath, "policy", ".vet/policy.yaml", "policy file path")
@@ -261,7 +261,7 @@ Run 'vet verify' before 'vet gate' to populate the verification record.`,
 	return cmd
 }
 
-func runGate(artifactRef, vetDir, policyPath string) error {
+func runGate(ctx context.Context, artifactRef, vetDir, policyPath string) error {
 	p, err := gate.LoadPolicy(policyPath)
 	if err != nil {
 		return fmt.Errorf("load policy: %w", err)
@@ -270,7 +270,7 @@ func runGate(artifactRef, vetDir, policyPath string) error {
 	s := store.New(vetDir)
 	e := gate.New(s, p)
 
-	result, err := e.Evaluate(artifactRef)
+	result, err := e.Evaluate(ctx, artifactRef)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,14 @@
 module github.com/provabl/vet
 
-go 1.26.2
+go 1.26.4
+
+require (
+	github.com/provabl/evidence v0.1.0
+	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,15 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/provabl/evidence v0.1.0 h1:eJQuQdg4wsebqWuGvGBTuN31kAFw7tV59ziwatoBGgs=
+github.com/provabl/evidence v0.1.0/go.mod h1:ypdlw3lvSj/EDiwmV/fg8Qd6Bm2ygDrPS7XiOEQaq0U=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/evidence/provider.go
+++ b/internal/evidence/provider.go
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-License-Identifier: Apache-2.0
+
+// Package vetasp is vet's (ASP, appraiser) pair for the provabl/evidence kernel.
+// It is the first re-pointing in phase two of ADR 0001: the gate verdict is no
+// longer computed by hand-rolled if-statements — it is produced by running a
+// Copland term through the kernel's CVM and appraising the resulting evidence,
+// then lowering the verdict to Cedar workload attributes.
+//
+// The pair lives in vet (not in evidence/providers) on purpose: the kernel's
+// CLAUDE.md says a provider may live in its tool's repo, and the falsifiable
+// invariant (no ASP-specific branch) constrains only the kernel packages
+// (term, ev, trust, asp, cvm, lower) — providers are not kernel. Keeping the
+// claim shape here, next to the store.GateResult it must feed, is what keeps
+// vet's Cedar output contract authored in one place.
+package vetasp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/provabl/evidence/asp"
+	"github.com/provabl/evidence/ev"
+	"github.com/provabl/evidence/term"
+
+	"github.com/provabl/vet/internal/store"
+)
+
+// ID keys this pair in the kernel registry.
+const ID term.ASPID = "vet"
+
+// TargetScheme is the opaque scheme the kernel routes on; the artifact ref is
+// carried after it. The kernel never parses past the scheme.
+const TargetScheme = "artifact://"
+
+// Target builds the kernel target for an artifact reference.
+func Target(artifactRef string) term.Target { return term.Target(TargetScheme + artifactRef) }
+
+// artifactRef recovers the artifact reference from a kernel target.
+func artifactRef(t term.Target) string { return strings.TrimPrefix(string(t), TargetScheme) }
+
+// RecordSource fetches the verification record for an artifact target. Injected
+// so the provider tests with no store/filesystem. Returns (nil, nil) when no
+// record exists — a fact about the world, not an error.
+type RecordSource interface {
+	Fetch(ctx context.Context, target term.Target) (*store.VerificationRecord, error)
+}
+
+// Provider assembles the vet pair from an injected record source.
+func Provider(src RecordSource) asp.Provider {
+	return asp.Provider{
+		ID:        ID,
+		Measurer:  measurer{src: src},
+		Appraiser: appraiser{},
+	}
+}
+
+// StoreSource is the production RecordSource: it reads the verification record
+// from the .vet/ store.
+type StoreSource struct{ Store *store.Store }
+
+// Fetch loads the record for the artifact named by the target.
+func (s StoreSource) Fetch(_ context.Context, t term.Target) (*store.VerificationRecord, error) {
+	return s.Store.LoadRecord(artifactRef(t))
+}
+
+// --- measurer: gather, do not judge -----------------------------------------
+
+type measurer struct{ src RecordSource }
+
+func (m measurer) Measure(ctx context.Context, in asp.MeasureIn) (ev.Measurement, error) {
+	rec, err := m.src.Fetch(ctx, in.Target)
+	if err != nil {
+		return ev.Measurement{}, fmt.Errorf("vet: fetch record: %w", err)
+	}
+	if rec == nil {
+		// No verification record — a recorded fact, never a pass. This is the
+		// kernel-native expression of gate's fail-closed path.
+		return ev.Measurement{
+			Status: ev.CollectFailed,
+			Detail: fmt.Sprintf("no verification record for %s — run 'vet verify' first", artifactRef(in.Target)),
+		}, nil
+	}
+	// vet does not bind in.Nonce: it has no native channel. Freshness rides the
+	// kernel's outer SIG over Seq(Nonce, Meas) — the whole reason vet is first.
+	payload, err := json.Marshal(rec)
+	if err != nil {
+		return ev.Measurement{}, fmt.Errorf("vet: marshal record: %w", err)
+	}
+	return ev.Measurement{Payload: payload, Status: ev.Collected}, nil
+}
+
+// --- appraiser: decode, judge, emit claims ----------------------------------
+
+// Claim keys for the Cedar workload contract. These PascalCase names are the
+// hard contract attest's Cedar PDP reads from gate-result.json (context.workload.*);
+// they are pinned by a golden test so they cannot silently drift.
+const (
+	ClaimSLSALevel    = "workload.SLSALevel"
+	ClaimSBOMPresent  = "workload.SBOMPresent"
+	ClaimCVECritical  = "workload.CVECritical"
+	ClaimCVEHigh      = "workload.CVEHigh"
+	ClaimSigned       = "workload.Signed"
+	ClaimArtifactHash = "workload.ArtifactHash"
+	// ClaimFailure carries one human-readable policy failure. Repeated; the gate
+	// reconstructs the bulleted Failures[] from these rather than splitting Reason.
+	ClaimFailure = "workload.failure"
+)
+
+type appraiser struct{}
+
+func (appraiser) Appraise(_ context.Context, in asp.AppraiseIn) (asp.Verdict, error) {
+	var rec store.VerificationRecord
+	if err := json.Unmarshal(in.Meas.Payload, &rec); err != nil {
+		return asp.Verdict{}, fmt.Errorf("vet: decode record: %w", err)
+	}
+
+	// Workload claims — always emitted, regardless of pass/fail, so a policy can
+	// read the posture even on a denial.
+	claims := []asp.Claim{
+		{Key: ClaimSLSALevel, Value: strconv.Itoa(rec.SLSALevel), Type: "long"},
+		{Key: ClaimSBOMPresent, Value: boolStr(rec.SBOMPresent), Type: "bool"},
+		{Key: ClaimCVECritical, Value: boolStr(rec.CVECritical), Type: "bool"},
+		{Key: ClaimCVEHigh, Value: boolStr(rec.CVEHigh), Type: "bool"},
+		{Key: ClaimSigned, Value: boolStr(rec.Signed), Type: "bool"},
+		{Key: ClaimArtifactHash, Value: rec.ArtifactHash, Type: "string"},
+	}
+
+	// Judgment — mirrors the policy rules gate.go enforced before this re-point.
+	var failures []string
+	if !rec.Signed {
+		failures = append(failures, "artifact is not signed — run 'vet sign' first")
+	}
+	if minLevel := atoiDefault(in.Params["min_slsa_level"], 0); minLevel > 0 && rec.SLSALevel < minLevel {
+		failures = append(failures, fmt.Sprintf("SLSA level %d is below minimum %d", rec.SLSALevel, minLevel))
+	}
+	switch in.Params["cve_threshold"] {
+	case "critical":
+		if rec.CVECritical {
+			failures = append(failures, "critical CVEs found in artifact SBOM")
+		}
+	case "high":
+		if rec.CVECritical || rec.CVEHigh {
+			failures = append(failures, "high or critical CVEs found in artifact SBOM")
+		}
+	}
+
+	for _, f := range failures {
+		claims = append(claims, asp.Claim{Key: ClaimFailure, Value: f, Type: "string"})
+	}
+
+	reason := "supply-chain provenance verified"
+	if len(failures) > 0 {
+		reason = strings.Join(failures, "; ")
+	}
+	return asp.Verdict{Pass: len(failures) == 0, Claims: claims, Reason: reason}, nil
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func atoiDefault(s string, def int) int {
+	if s == "" {
+		return def
+	}
+	if n, err := strconv.Atoi(s); err == nil {
+		return n
+	}
+	return def
+}

--- a/internal/evidence/provider_test.go
+++ b/internal/evidence/provider_test.go
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-License-Identifier: Apache-2.0
+
+package vetasp_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/provabl/evidence/asp"
+	"github.com/provabl/evidence/cvm"
+	"github.com/provabl/evidence/lower"
+	"github.com/provabl/evidence/term"
+
+	vetasp "github.com/provabl/vet/internal/evidence"
+	"github.com/provabl/vet/internal/store"
+)
+
+// stubSource returns a fixed record (or nil for the missing-record case) for any
+// target, so the provider tests run with no store and no filesystem.
+type stubSource struct{ rec *store.VerificationRecord }
+
+func (s stubSource) Fetch(context.Context, term.Target) (*store.VerificationRecord, error) {
+	return s.rec, nil
+}
+
+// appraise builds the CVM, runs the canonical term, and appraises — the same
+// path gate.Evaluate drives. Returns the appraised verdict.
+func appraise(t *testing.T, rec *store.VerificationRecord, params term.Params) asp.Verdict {
+	t.Helper()
+	reg := asp.NewRegistry()
+	if err := reg.Register(vetasp.Provider(stubSource{rec: rec})); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	am, err := vetasp.NewEphemeralAM()
+	if err != nil {
+		t.Fatalf("am: %v", err)
+	}
+	c := cvm.New(reg, am, am, nil)
+	protocol := term.Seq(
+		term.Nonce(),
+		term.Seq(term.Meas(term.Self, vetasp.ID, vetasp.Target("ghcr.io/test/app:v1.0"), params), term.Sig()),
+	)
+	bundle, ch, err := c.Run(context.Background(), protocol)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	v, err := c.Appraise(context.Background(), bundle, ch)
+	if err != nil {
+		t.Fatalf("appraise: %v", err)
+	}
+	return v
+}
+
+func signedRecord() *store.VerificationRecord {
+	return &store.VerificationRecord{
+		ArtifactRef:  "ghcr.io/test/app:v1.0",
+		ArtifactHash: "sha256:abc123",
+		Signed:       true,
+		SLSALevel:    2,
+		SBOMPresent:  true,
+	}
+}
+
+func TestProvider_PassEmitsFullClaimSet(t *testing.T) {
+	v := appraise(t, signedRecord(), term.Params{"min_slsa_level": "2", "cve_threshold": "critical"})
+	if !v.Pass {
+		t.Fatalf("expected pass, reason: %s", v.Reason)
+	}
+
+	attrs := lower.ToAttributes(v)
+	// Golden: the exact Cedar workload key set the contract requires.
+	want := map[string]string{
+		"workload.SLSALevel":    "long",
+		"workload.SBOMPresent":  "bool",
+		"workload.CVECritical":  "bool",
+		"workload.CVEHigh":      "bool",
+		"workload.Signed":       "bool",
+		"workload.ArtifactHash": "string",
+		"attested":              "bool", // synthesized by lower.ToAttributes
+	}
+	for k, typ := range want {
+		a, ok := attrs[k]
+		if !ok {
+			t.Errorf("missing attribute %q", k)
+			continue
+		}
+		if a.Type != typ {
+			t.Errorf("attr %q type = %q, want %q", k, a.Type, typ)
+		}
+	}
+	// No stray workload keys beyond the contract (catches accidental additions).
+	var got []string
+	for k := range attrs {
+		got = append(got, k)
+	}
+	sort.Strings(got)
+	if len(got) != len(want) {
+		t.Errorf("attribute set = %v (%d), want %d keys", got, len(got), len(want))
+	}
+	if attrs["workload.SLSALevel"].Value != "2" {
+		t.Errorf("SLSALevel = %q, want 2", attrs["workload.SLSALevel"].Value)
+	}
+	if attrs["attested"].Value != "true" {
+		t.Errorf("attested = %q, want true", attrs["attested"].Value)
+	}
+}
+
+func TestProvider_FailBelowMinSLSA(t *testing.T) {
+	rec := signedRecord()
+	rec.SLSALevel = 1
+	v := appraise(t, rec, term.Params{"min_slsa_level": "2"})
+	if v.Pass {
+		t.Fatal("expected fail for SLSA 1 < min 2")
+	}
+}
+
+func TestProvider_FailCritical(t *testing.T) {
+	rec := signedRecord()
+	rec.CVECritical = true
+	v := appraise(t, rec, term.Params{"cve_threshold": "critical"})
+	if v.Pass {
+		t.Fatal("expected fail for critical CVE under critical threshold")
+	}
+}
+
+// The "high" threshold semantics the kernel reference provider lacks: a record
+// with a HIGH (but not critical) CVE must FAIL under cve_threshold=high, and
+// PASS under cve_threshold=critical. Proves high != critical.
+func TestProvider_HighThresholdDistinctFromCritical(t *testing.T) {
+	rec := signedRecord()
+	rec.CVEHigh = true
+	rec.CVECritical = false
+
+	vHigh := appraise(t, rec, term.Params{"cve_threshold": "high"})
+	if vHigh.Pass {
+		t.Error("expected FAIL: high CVE under high threshold")
+	}
+
+	vCrit := appraise(t, rec, term.Params{"cve_threshold": "critical"})
+	if !vCrit.Pass {
+		t.Errorf("expected PASS: high CVE under critical threshold, reason: %s", vCrit.Reason)
+	}
+}
+
+// Freshness: a bundle appraised against a DIFFERENT challenge than the one issued
+// must fail at the spine before any workload claim is trusted.
+func TestProvider_FreshnessNonceMismatch(t *testing.T) {
+	reg := asp.NewRegistry()
+	if err := reg.Register(vetasp.Provider(stubSource{rec: signedRecord()})); err != nil {
+		t.Fatal(err)
+	}
+	am, err := vetasp.NewEphemeralAM()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := cvm.New(reg, am, am, nil)
+	protocol := term.Seq(
+		term.Nonce(),
+		term.Seq(term.Meas(term.Self, vetasp.ID, vetasp.Target("x"), term.Params{}), term.Sig()),
+	)
+	bundle, _, err := c.Run(context.Background(), protocol)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Appraise with a fresh, unrelated challenge — the issued nonce is discarded.
+	stale := cvm.Challenge{Nonce: []byte("a-different-32-byte-challenge....")}
+	v, err := c.Appraise(context.Background(), bundle, stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Pass {
+		t.Fatal("expected freshness failure on nonce mismatch")
+	}
+}
+
+// Missing record: the measurer reports CollectFailed; appraisal fails and emits
+// no workload.* claims, only the kernel's vet.collected=false marker.
+func TestProvider_MissingRecord(t *testing.T) {
+	v := appraise(t, nil, term.Params{})
+	if v.Pass {
+		t.Fatal("expected fail when no record exists")
+	}
+	attrs := lower.ToAttributes(v)
+	if _, ok := attrs["workload.Signed"]; ok {
+		t.Error("expected no workload.* claims on a CollectFailed measurement")
+	}
+	if attrs["vet.collected"].Value != "false" {
+		t.Errorf("expected vet.collected=false, got %q", attrs["vet.collected"].Value)
+	}
+}

--- a/internal/evidence/trust.go
+++ b/internal/evidence/trust.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-License-Identifier: Apache-2.0
+
+package vetasp
+
+import (
+	"crypto/ed25519"
+	"fmt"
+
+	"github.com/provabl/evidence/trust"
+)
+
+// amKeyID names the attestation-manager key on the Signed evidence node.
+const amKeyID = "vet-am-ephemeral"
+
+// EphemeralAM is the kernel's attestation-manager key for one gate evaluation.
+// It implements BOTH trust.Signer (the SIG built-in) and trust.Store (spine
+// verification during appraisal), backed by a freshly generated ed25519 keypair.
+//
+// The key is ephemeral on purpose. vet's appraisal is in-process and synchronous
+// — Run signs, Appraise verifies, in the same call — so the public half that
+// signed the bundle moments earlier is the only key the spine check needs. The
+// durable artifact is the lowered gate-result.json, never the evidence bundle,
+// so nothing reads this signature after the process exits. A persisted key would
+// add a key-management surface for no benefit and would weaken freshness: it
+// would let a stale bundle from a prior run verify, which is exactly what the
+// nonce+SIG spine exists to prevent. (A named/persisted key earns its place only
+// when evidence is stored and appraised out-of-process — a non-goal here.)
+type EphemeralAM struct {
+	priv  ed25519.PrivateKey
+	pub   ed25519.PublicKey
+	keyID string
+}
+
+// NewEphemeralAM generates a fresh attestation-manager keypair.
+func NewEphemeralAM() (*EphemeralAM, error) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		return nil, fmt.Errorf("vet: generate AM key: %w", err)
+	}
+	return &EphemeralAM{priv: priv, pub: pub, keyID: amKeyID}, nil
+}
+
+// Sign implements trust.Signer.
+func (a *EphemeralAM) Sign(msg []byte) (sig []byte, keyID string, err error) {
+	return ed25519.Sign(a.priv, msg), a.keyID, nil
+}
+
+// Verify implements trust.Store: it verifies a signature made by this AM's key.
+func (a *EphemeralAM) Verify(keyID string, msg, sig []byte) (bool, error) {
+	if keyID != a.keyID {
+		return false, nil
+	}
+	return ed25519.Verify(a.pub, msg, sig), nil
+}
+
+// Root implements trust.Store. vet brings no external trust roots (its signature
+// verification, when wired, is the appraiser's concern via injection), so there
+// are none to resolve here.
+func (a *EphemeralAM) Root(string) (trust.Root, bool) { return trust.Root{}, false }

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -7,12 +7,20 @@
 package gate
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
-	"github.com/provabl/vet/internal/store"
+	"github.com/provabl/evidence/asp"
+	"github.com/provabl/evidence/cvm"
+	"github.com/provabl/evidence/lower"
+	"github.com/provabl/evidence/term"
 	"gopkg.in/yaml.v3"
+
+	vetasp "github.com/provabl/vet/internal/evidence"
+	"github.com/provabl/vet/internal/store"
 )
 
 // Policy is the vet verification policy (.vet/policy.yaml).
@@ -62,91 +70,133 @@ type EvaluateResult struct {
 	ArtifactRef   string
 	ArtifactHash  string
 	PolicyMet     bool
-	MissingRecord bool   // true when no prior 'vet verify' record exists
+	MissingRecord bool // true when no prior 'vet verify' record exists
 	Failures      []string
 	GateResult    *store.GateResult
 }
 
 // Evaluate looks up the verification record for artifactRef and evaluates it
-// against the policy. Writes gate-result.json with Cedar workload attributes.
+// against the policy, producing the verdict THROUGH the provabl/evidence kernel:
+// it runs the canonical Copland term Seq(Nonce, Seq(Meas, Sig)) through the CVM,
+// appraises the resulting evidence bundle, and lowers the verdict to the Cedar
+// workload attributes written to gate-result.json. The judgment is no longer
+// hand-rolled here — it lives in vet's (ASP, appraiser) pair (internal/evidence).
 //
 // If no verification record exists (vet verify was never run for this artifact),
-// Evaluate writes a fail-closed gate result (PolicyMet=false, all attributes false/0)
-// and returns an EvaluateResult with a MissingRecord flag set. Callers should print
-// the guidance message to steer operators toward running 'vet verify' first.
-func (e *Evaluator) Evaluate(artifactRef string) (*EvaluateResult, error) {
-	rec, err := e.store.LoadRecord(artifactRef)
+// the measurer returns a CollectFailed measurement; appraisal fails the spine of
+// claims, and Evaluate writes a fail-closed gate result (PolicyMet=false, all
+// attributes false/0) with MissingRecord=true so the caller can print guidance.
+func (e *Evaluator) Evaluate(ctx context.Context, artifactRef string) (*EvaluateResult, error) {
+	reg := asp.NewRegistry()
+	if err := reg.Register(vetasp.Provider(vetasp.StoreSource{Store: e.store})); err != nil {
+		return nil, fmt.Errorf("register vet provider: %w", err)
+	}
+	am, err := vetasp.NewEphemeralAM()
 	if err != nil {
-		return nil, fmt.Errorf("load record: %w", err)
+		return nil, err
 	}
-	if rec == nil {
-		// No record exists — write a fail-closed gate result and return with
-		// MissingRecord=true so the caller can print actionable guidance.
-		gateResult := &store.GateResult{
-			Artifact:    artifactRef,
-			Signed:      false,
-			SLSALevel:   0,
-			SBOMPresent: false,
-			CVECritical: false,
-			CVEHigh:     false,
-			PolicyMet:   false,
-			EvaluatedAt: time.Now(),
-		}
-		_ = e.store.SaveGateResult(gateResult) // best-effort; don't mask the real error
-		return &EvaluateResult{
-			ArtifactRef:   artifactRef,
-			PolicyMet:     false,
-			MissingRecord: true,
-			Failures:      []string{"no verification record — run 'vet verify <artifact>' before 'vet gate'"},
-			GateResult:    gateResult,
-		}, nil
+	c := cvm.New(reg, am, am, nil)
+
+	// Policy values flow to the appraiser through the term's params, so the
+	// kernel — not gate — applies them.
+	params := term.Params{}
+	if e.policy.MinSLSALevel > 0 {
+		params["min_slsa_level"] = strconv.Itoa(e.policy.MinSLSALevel)
 	}
-
-	var failures []string
-
-	if !rec.Signed {
-		failures = append(failures, "artifact is not signed — run 'vet sign' first")
+	if e.policy.CVEThreshold != "" {
+		params["cve_threshold"] = e.policy.CVEThreshold
 	}
+	protocol := term.Seq(
+		term.Nonce(),
+		term.Seq(
+			term.Meas(term.Self, vetasp.ID, vetasp.Target(artifactRef), params),
+			term.Sig(),
+		),
+	)
 
-	if e.policy.MinSLSALevel > 0 && rec.SLSALevel < e.policy.MinSLSALevel {
-		failures = append(failures,
-			fmt.Sprintf("SLSA level %d is below minimum %d", rec.SLSALevel, e.policy.MinSLSALevel))
+	bundle, ch, err := c.Run(ctx, protocol)
+	if err != nil {
+		return nil, fmt.Errorf("run attestation: %w", err)
+	}
+	verdict, err := c.Appraise(ctx, bundle, ch)
+	if err != nil {
+		return nil, fmt.Errorf("appraise: %w", err)
 	}
 
-	switch e.policy.CVEThreshold {
-	case "critical":
-		if rec.CVECritical {
-			failures = append(failures, "critical CVEs found in artifact SBOM")
-		}
-	case "high":
-		if rec.CVECritical || rec.CVEHigh {
-			failures = append(failures, "high or critical CVEs found in artifact SBOM")
-		}
-	}
+	attrs := lower.ToAttributes(verdict)
+	missingRecord := isMissingRecord(verdict)
+	gateResult := gateResultFromAttrs(artifactRef, attrs, verdict.Pass)
 
-	policyMet := len(failures) == 0
-
-	gateResult := &store.GateResult{
-		Artifact:     artifactRef,
-		ArtifactHash: rec.ArtifactHash,
-		SLSALevel:    rec.SLSALevel,
-		SBOMPresent:  rec.SBOMPresent,
-		CVECritical:  rec.CVECritical,
-		CVEHigh:      rec.CVEHigh,
-		Signed:       rec.Signed,
-		PolicyMet:    policyMet,
-		EvaluatedAt:  time.Now(),
-	}
-
-	if err := e.store.SaveGateResult(gateResult); err != nil {
+	// Best-effort on the missing-record path (don't mask a real save error
+	// otherwise), matching prior behavior.
+	if missingRecord {
+		_ = e.store.SaveGateResult(gateResult)
+	} else if err := e.store.SaveGateResult(gateResult); err != nil {
 		return nil, fmt.Errorf("save gate result: %w", err)
 	}
 
+	failures := failuresFromVerdict(verdict)
+	if missingRecord {
+		failures = []string{"no verification record — run 'vet verify <artifact>' before 'vet gate'"}
+	}
+
 	return &EvaluateResult{
-		ArtifactRef:  artifactRef,
-		ArtifactHash: rec.ArtifactHash,
-		PolicyMet:    policyMet,
-		Failures:     failures,
-		GateResult:   gateResult,
+		ArtifactRef:   artifactRef,
+		ArtifactHash:  gateResult.ArtifactHash,
+		PolicyMet:     verdict.Pass,
+		MissingRecord: missingRecord,
+		Failures:      failures,
+		GateResult:    gateResult,
 	}, nil
+}
+
+// isMissingRecord reports whether the bundle's only finding was that the
+// measurement could not be taken (CollectFailed) — surfaced by the kernel as a
+// "<asp>.collected=false" claim and the absence of any workload.* claim.
+func isMissingRecord(v asp.Verdict) bool {
+	for _, c := range v.Claims {
+		if c.Key == string(vetasp.ID)+".collected" && c.Value == "false" {
+			return true
+		}
+	}
+	return false
+}
+
+// failuresFromVerdict reconstructs the bulleted failure list the CLI prints from
+// the structured failure claims the appraiser emitted (not by splitting Reason).
+func failuresFromVerdict(v asp.Verdict) []string {
+	var out []string
+	for _, c := range v.Claims {
+		if c.Key == vetasp.ClaimFailure {
+			out = append(out, c.Value)
+		}
+	}
+	return out
+}
+
+// gateResultFromAttrs is the single chokepoint mapping lowered Cedar attributes
+// back to the store.GateResult contract. Absent workload.* attributes (the
+// CollectFailed / missing-record case) default to zero/false, exactly
+// reproducing the prior fail-closed result.
+func gateResultFromAttrs(artifactRef string, attrs map[string]lower.Attr, policyMet bool) *store.GateResult {
+	return &store.GateResult{
+		Artifact:     artifactRef,
+		ArtifactHash: attrs[vetasp.ClaimArtifactHash].Value,
+		SLSALevel:    attrInt(attrs, vetasp.ClaimSLSALevel),
+		SBOMPresent:  attrBool(attrs, vetasp.ClaimSBOMPresent),
+		CVECritical:  attrBool(attrs, vetasp.ClaimCVECritical),
+		CVEHigh:      attrBool(attrs, vetasp.ClaimCVEHigh),
+		Signed:       attrBool(attrs, vetasp.ClaimSigned),
+		PolicyMet:    policyMet,
+		EvaluatedAt:  time.Now(),
+	}
+}
+
+func attrBool(attrs map[string]lower.Attr, key string) bool {
+	return attrs[key].Value == "true"
+}
+
+func attrInt(attrs map[string]lower.Attr, key string) int {
+	n, _ := strconv.Atoi(attrs[key].Value)
+	return n
 }

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -4,6 +4,7 @@
 package gate_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -32,7 +33,7 @@ func TestGateWritesCedarAttributes(t *testing.T) {
 	})
 
 	e := gate.New(s, gate.DefaultPolicy())
-	result, err := e.Evaluate("ghcr.io/test/app:v1.0")
+	result, err := e.Evaluate(context.Background(), "ghcr.io/test/app:v1.0")
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
@@ -58,7 +59,7 @@ func TestGatePolicyViolationMinSLSA(t *testing.T) {
 
 	p := &gate.Policy{MinSLSALevel: 2}
 	e := gate.New(s, p)
-	result, err := e.Evaluate("image:v1")
+	result, err := e.Evaluate(context.Background(), "image:v1")
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
@@ -73,7 +74,7 @@ func TestGatePolicyViolationMinSLSA(t *testing.T) {
 func TestGateNoRecordWritesFailClosedResult(t *testing.T) {
 	s := store.New(t.TempDir())
 	e := gate.New(s, gate.DefaultPolicy())
-	result, err := e.Evaluate("no-record:latest")
+	result, err := e.Evaluate(context.Background(), "no-record:latest")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -101,11 +102,42 @@ func TestGateCVEPolicyViolation(t *testing.T) {
 
 	p := &gate.Policy{CVEThreshold: "critical"}
 	e := gate.New(s, p)
-	result, err := e.Evaluate("image:v1")
+	result, err := e.Evaluate(context.Background(), "image:v1")
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
 	if result.PolicyMet {
 		t.Error("policy should NOT be met when critical CVEs found")
+	}
+}
+
+// A high (but not critical) CVE must fail under the "high" threshold and pass
+// under "critical" — the threshold semantics now enforced by the evidence
+// appraiser, exercised end-to-end through gate.Evaluate.
+func TestGateHighThresholdViaKernel(t *testing.T) {
+	s := store.New(t.TempDir())
+	seedRecord(t, s, &store.VerificationRecord{
+		ArtifactRef: "image:v1",
+		Signed:      true,
+		CVEHigh:     true,
+		CVECritical: false,
+	})
+
+	high := gate.New(s, &gate.Policy{CVEThreshold: "high"})
+	rHigh, err := high.Evaluate(context.Background(), "image:v1")
+	if err != nil {
+		t.Fatalf("Evaluate (high): %v", err)
+	}
+	if rHigh.PolicyMet {
+		t.Error("policy should NOT be met: high CVE under high threshold")
+	}
+
+	crit := gate.New(s, &gate.Policy{CVEThreshold: "critical"})
+	rCrit, err := crit.Evaluate(context.Background(), "image:v1")
+	if err != nil {
+		t.Fatalf("Evaluate (critical): %v", err)
+	}
+	if !rCrit.PolicyMet {
+		t.Errorf("policy should be met: high CVE under critical threshold, failures: %v", rCrit.Failures)
 	}
 }


### PR DESCRIPTION
Closes #7. Phase-two **Stream A, step 1** of [ADR 0001](https://github.com/provabl/provabl/blob/main/docs/adr/0001-evidence-kernel-beneath-cedar.md) — tracked in the epic hub provabl/evidence#2.

## What changes
`vet gate` no longer judges with hand-rolled if-statements. It now runs the canonical Copland term `Seq(Nonce, Seq(Meas, Sig))` through the evidence kernel's CVM, appraises the evidence bundle, and lowers the verdict to the Cedar workload attributes written to `.vet/gate-result.json`. The facts attest's PDP trusts become **appraised and freshness-bound** (kernel nonce + SIG spine), not bare computations.

## Design decision — Option B (vet-owned provider, one PR)
vet defines its own `(ASP, appraiser)` pair in `internal/evidence` rather than importing `evidence/providers/vet`:
- The kernel CLAUDE.md blesses tool-owned providers (*"a provider may move into its tool's repo — the import direction is identical"*).
- The no-ASP-branch invariant constrains only the **kernel** packages; providers are not kernel.
- The kernel's reference `Bundle` is structurally insufficient for vet's real contract (it lacks `CVEHigh`/`SBOMPresent`/`Signed`/`ArtifactHash` and the high-vs-critical threshold). Authoring the claim shape next to `store.GateResult` is what prevents Cedar-contract drift.

No evidence-repo change. New dep: `github.com/provabl/evidence v0.1.0`.

## Files
- **`internal/evidence/provider.go`** (new) — the vet ASP pair. `VerificationRecord` is the measurer payload (round-trips → field fidelity); missing record → `CollectFailed` (kernel-native fail-closed); appraiser emits the full PascalCase `workload.*` claim set + structured `workload.failure` claims, applying `min_slsa_level` + `cve_threshold` (incl. the **`high`** semantics the reference provider lacks).
- **`internal/evidence/trust.go`** (new) — ephemeral per-run ed25519 AM (Signer+Store). Ephemeral on purpose: in-process Run/Appraise; the durable artifact is the lowered JSON; a persisted key would weaken freshness.
- **`internal/gate/gate.go`** — `Evaluate(ctx, ref)` drives the CVM; `gateResultFromAttrs` is the single attrs→GateResult chokepoint; missing-record + failure list reconstructed from claims.
- **`cmd/vet/main.go`** — thread `cmd.Context()` into `Evaluate`; stdout + exit path unchanged.

## Contract preserved (hard constraint — attest reads this file)
- All **4 pre-existing gate tests pass unchanged**.
- `gate-result.json` **and** stdout are **byte-identical** old-vs-new for both the pass and missing-record cases (verified against an `origin/main` build, ignoring the timestamp).

## New tests
Provider: pass / fail-min-SLSA / fail-critical / **high≠critical** / freshness nonce-mismatch / missing-record (golden-asserts the exact claim key set). Plus an end-to-end `TestGateHighThresholdViaKernel`.

## Verification
`go vet ./...` clean · `go test ./...` green · `go build ./...` ok.

## Follow-up (filed separately)
`verify.go` doesn't set `SBOMPresent`/`ArtifactHash` on the record — pre-existing, out of scope; issue to follow.