### PR TITLE
fix(verify): populate SBOMPresent and ArtifactHash on the record (closes #10)

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -23,8 +23,8 @@ type VerificationRecord struct {
 	ArtifactHash  string    `json:"artifact_hash"`
 	Signed        bool      `json:"signed"`
 	SignerSubject string    `json:"signer_subject,omitempty"`
-	RekorLogID   string    `json:"rekor_log_id,omitempty"`
-	SLSALevel     int       `json:"slsa_level"`    // 0 = not verified
+	RekorLogID    string    `json:"rekor_log_id,omitempty"`
+	SLSALevel     int       `json:"slsa_level"` // 0 = not verified
 	SBOMPresent   bool      `json:"sbom_present"`
 	CVECritical   bool      `json:"cve_critical"`
 	CVEHigh       bool      `json:"cve_high"`
@@ -48,8 +48,8 @@ type GateResult struct {
 
 // Policy is read from .vet/policy.yaml.
 type Policy struct {
-	MinSLSALevel int      `yaml:"min_slsa_level"` // default 0 (no requirement)
-	CVEThreshold string   `yaml:"cve_threshold"`  // "critical", "high", "medium", ""
+	MinSLSALevel      int      `yaml:"min_slsa_level"` // default 0 (no requirement)
+	CVEThreshold      string   `yaml:"cve_threshold"`  // "critical", "high", "medium", ""
 	AllowedSigningIDs []string `yaml:"allowed_signing_ids,omitempty"`
 }
 
@@ -128,6 +128,17 @@ func (s *Store) SBOMPath(artifactRef, format string) string {
 		ext = ".cyclonedx.json"
 	}
 	return filepath.Join(s.dir, "sboms", key+ext)
+}
+
+// HasSBOM reports whether an SBOM has been generated for the artifact, in either
+// SPDX or CycloneDX format. Used to populate VerificationRecord.SBOMPresent.
+func (s *Store) HasSBOM(artifactRef string) bool {
+	for _, format := range []string{"spdx", "cyclonedx"} {
+		if _, err := os.Stat(s.SBOMPath(artifactRef, format)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // Dir returns the root .vet/ directory path.

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -8,10 +8,12 @@ package verify
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -35,9 +37,9 @@ func (r *defaultRunner) Run(ctx context.Context, name string, args ...string) ([
 
 // Options controls what vet verify checks.
 type Options struct {
-	Source        string // github.com/org/repo — required for SLSA check
-	MinSLSALevel  int    // 0 = any/none, 1/2/3 = minimum
-	CheckCVEs     string // "critical", "high", "medium", "" = skip
+	Source         string // github.com/org/repo — required for SLSA check
+	MinSLSALevel   int    // 0 = any/none, 1/2/3 = minimum
+	CheckCVEs      string // "critical", "high", "medium", "" = skip
 	SigningIDRegex string // certificate-identity-regexp for cosign verify
 }
 
@@ -64,16 +66,17 @@ func NewWithRunner(r Runner, s *store.Store) *Verifier {
 
 // VerifyResult summarises all verification checks.
 type VerifyResult struct {
-	ArtifactRef  string
-	Signed       bool
+	ArtifactRef   string
+	ArtifactHash  string // sha256:… digest when derivable from the ref or a local file
+	Signed        bool
 	SignerSubject string
-	RekorLogID   string
-	SLSALevel    int // 0 = not present/verified
-	SBOMPresent  bool
-	CVECritical  bool
-	CVEHigh      bool
-	PolicyMet    bool
-	Failures     []string // human-readable failure list
+	RekorLogID    string
+	SLSALevel     int // 0 = not present/verified
+	SBOMPresent   bool
+	CVECritical   bool
+	CVEHigh       bool
+	PolicyMet     bool
+	Failures      []string // human-readable failure list
 }
 
 // Verify runs all configured checks and returns a result.
@@ -106,7 +109,11 @@ func (v *Verifier) Verify(ctx context.Context, artifactRef string, opts Options)
 		}
 	}
 
-	// 3. CVE check (requires SBOM in store)
+	// 3. SBOM presence + artifact hash (independent of the CVE check).
+	result.SBOMPresent = v.store.HasSBOM(artifactRef)
+	result.ArtifactHash = artifactHash(artifactRef)
+
+	// 4. CVE check (requires SBOM in store)
 	if opts.CheckCVEs != "" {
 		sbomPath := v.store.SBOMPath(artifactRef, "spdx")
 		critical, high, cveErr := v.checkCVEs(ctx, sbomPath)
@@ -117,7 +124,7 @@ func (v *Verifier) Verify(ctx context.Context, artifactRef string, opts Options)
 		// CVE check failure is non-blocking (SBOM may not exist yet)
 	}
 
-	// 4. Policy evaluation
+	// 5. Policy evaluation
 	var policyFailures []string
 	if !result.Signed {
 		policyFailures = append(policyFailures, "artifact is not signed")
@@ -142,19 +149,45 @@ func (v *Verifier) Verify(ctx context.Context, artifactRef string, opts Options)
 
 	// Persist record.
 	rec := &store.VerificationRecord{
-		ArtifactRef:  artifactRef,
-		Signed:       result.Signed,
+		ArtifactRef:   artifactRef,
+		ArtifactHash:  result.ArtifactHash,
+		Signed:        result.Signed,
 		SignerSubject: result.SignerSubject,
-		RekorLogID:   result.RekorLogID,
-		SLSALevel:    result.SLSALevel,
-		CVECritical:  result.CVECritical,
-		CVEHigh:      result.CVEHigh,
-		VerifiedAt:   time.Now(),
-		Source:       opts.Source,
+		RekorLogID:    result.RekorLogID,
+		SLSALevel:     result.SLSALevel,
+		SBOMPresent:   result.SBOMPresent,
+		CVECritical:   result.CVECritical,
+		CVEHigh:       result.CVEHigh,
+		VerifiedAt:    time.Now(),
+		Source:        opts.Source,
 	}
 	_ = v.store.SaveRecord(rec) // non-fatal
 
 	return result, nil
+}
+
+// artifactHash derives the subject digest for an artifact reference. For an image
+// ref pinned by digest (…@sha256:abc…) it returns that digest. For a local file
+// (./path or /path) it returns the sha256 of the file contents. For a bare tag
+// (no digest, not a local file) it returns "" — the digest cannot be known
+// without pulling the image, and an empty hash is honest rather than fabricated.
+func artifactHash(ref string) string {
+	if i := strings.Index(ref, "@sha256:"); i != -1 {
+		return ref[i+1:] // "sha256:abc…"
+	}
+	if strings.HasPrefix(ref, "./") || strings.HasPrefix(ref, "/") {
+		f, err := os.Open(ref) // #nosec G304 — operator-supplied artifact path
+		if err != nil {
+			return ""
+		}
+		defer func() { _ = f.Close() }()
+		h := sha256.New()
+		if _, err := io.Copy(h, f); err != nil {
+			return ""
+		}
+		return fmt.Sprintf("sha256:%x", h.Sum(nil))
+	}
+	return ""
 }
 
 // verifySig calls cosign to verify the artifact's signature.

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-License-Identifier: Apache-2.0
+
+package verify
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestArtifactHash_DigestPinnedRef(t *testing.T) {
+	ref := "ghcr.io/org/app@sha256:abc123def456"
+	if got := artifactHash(ref); got != "sha256:abc123def456" {
+		t.Errorf("artifactHash(%q) = %q, want sha256:abc123def456", ref, got)
+	}
+}
+
+func TestArtifactHash_BareTagIsEmpty(t *testing.T) {
+	// A tag without a digest cannot be hashed without pulling — empty is honest.
+	if got := artifactHash("ghcr.io/org/app:v1.0"); got != "" {
+		t.Errorf("artifactHash(bare tag) = %q, want empty", got)
+	}
+}
+
+func TestArtifactHash_LocalFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "artifact.bin")
+	content := []byte("hello provabl")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	want := fmt.Sprintf("sha256:%x", sha256.Sum256(content))
+	if got := artifactHash(path); got != want {
+		t.Errorf("artifactHash(local file) = %q, want %q", got, want)
+	}
+}
+
+func TestArtifactHash_MissingLocalFileIsEmpty(t *testing.T) {
+	if got := artifactHash("/nonexistent/path/artifact.bin"); got != "" {
+		t.Errorf("artifactHash(missing file) = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
Closes #10. Loose end from the vet#7 evidence-kernel re-point (#9).

## Problem
The kernel-routed gate emits `workload.SBOMPresent` and `workload.ArtifactHash` as Cedar claims, but `verify.go` never set those fields on the `VerificationRecord` — so they were **perpetually false/empty** regardless of reality. Any future Cedar policy keying on `context.workload.sbom_present` or `.artifact_hash` would have been misled.

## Fix
- **`store.HasSBOM(ref)`** — reports whether an SBOM (SPDX or CycloneDX) exists for the artifact → sets `SBOMPresent`.
- **`verify.artifactHash(ref)`** — derives the subject digest: the `@sha256:` digest from a pinned image ref, or the sha256 of a local file; **empty for a bare tag** (honest — the digest can't be known without pulling) → sets `ArtifactHash`.
- `Verify` sets both on `VerifyResult` and the persisted record, independent of the CVE check.

## Tests
`artifactHash` digest-ref / bare-tag / local-file / missing-file. `go build` / `go vet` / `go test` green.