### PR TITLE
chore: copyright holder → Playground Logic LLC

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Scott Friedman
+# SPDX-FileCopyrightText: 2026 Playground Logic LLC
 # SPDX-License-Identifier: Apache-2.0
 
 name: CI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Scott Friedman
+# SPDX-FileCopyrightText: 2026 Playground Logic LLC
 # SPDX-License-Identifier: Apache-2.0
 
 name: Release

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 Playground Logic
+   Copyright 2026 Playground Logic LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,1 +1,1 @@
-Copyright 2026 Scott Friedman
+Copyright 2026 Playground Logic LLC

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -3,5 +3,5 @@ version = 1
 [[annotations]]
 path = ["**.json", "**.yaml", "**.yml", "**.sql", "**.md", "**.toml", "**.cedar", "**.cast"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2026 Scott Friedman"
+SPDX-FileCopyrightText = "2026 Playground Logic LLC"
 SPDX-License-Identifier = "Apache-2.0"

--- a/cmd/vet/main.go
+++ b/cmd/vet/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/internal/evidence/provider.go
+++ b/internal/evidence/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package vetasp is vet's (ASP, appraiser) pair for the provabl/evidence kernel.

--- a/internal/evidence/provider_test.go
+++ b/internal/evidence/provider_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package vetasp_test

--- a/internal/evidence/trust.go
+++ b/internal/evidence/trust.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package vetasp

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package gate evaluates a verification record against a policy and writes

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package gate_test

--- a/internal/sbom/sbom.go
+++ b/internal/sbom/sbom.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package sbom generates and attests Software Bills of Materials using syft

--- a/internal/sign/sign.go
+++ b/internal/sign/sign.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package sign wraps the cosign CLI for keyless artifact signing.

--- a/internal/sign/sign_test.go
+++ b/internal/sign/sign_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package sign_test

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package store manages the .vet/ directory and artifact verification records.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package store_test

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package verify checks cosign signatures, SLSA provenance, and CVE status.

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Scott Friedman
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package verify


### PR DESCRIPTION
Normalizes the copyright holder to **2026 Playground Logic LLC** (the legal entity) across SPDX file headers, NOTICE, REUSE.toml, and the LICENSE footer. No behavior change; build + tests unaffected.