### PR TITLE
feat(verify): real SBOM parsing + CVE/OSV checking, fail-closed (closes #15, #13)

### DIFF
--- a/cmd/vet/main.go
+++ b/cmd/vet/main.go
@@ -159,15 +159,19 @@ func runVerify(artifactRef, vetDir string, opts verify.Options) error {
 	}
 
 	if opts.CheckCVEs != "" {
-		if !result.CVECritical && !result.CVEHigh {
-			fmt.Println("  ✓ No critical/high CVEs found")
-		} else {
-			if result.CVECritical {
-				fmt.Println("  ✗ Critical CVEs found")
-			}
+		switch {
+		case result.CVECritical:
+			fmt.Println("  ✗ Critical CVEs found")
 			if result.CVEHigh {
 				fmt.Println("  ✗ High CVEs found")
 			}
+		case result.CVEHigh:
+			fmt.Println("  ✗ High CVEs found")
+		case !result.SBOMPresent:
+			// The CVE gate could not run; the policy violation below explains it.
+			fmt.Println("  ✗ CVE check could not run (no SBOM)")
+		default:
+			fmt.Println("  ✓ No critical/high CVEs found")
 		}
 	}
 

--- a/internal/sbom/parse.go
+++ b/internal/sbom/parse.go
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package sbom
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Package is the minimal identity of a software component extracted from an SBOM,
+// enough to query a vulnerability database. PURL is preferred when present (it
+// encodes the ecosystem); Name/Version/Ecosystem are the fallback.
+type Package struct {
+	Name      string
+	Version   string
+	Ecosystem string // OSV ecosystem (e.g. "npm", "Go", "PyPI"), when derivable
+	PURL      string // package URL, e.g. "pkg:golang/github.com/foo/bar@v1.2.3"
+}
+
+// ErrNoSBOM is returned by Load when the SBOM file does not exist.
+var ErrNoSBOM = errors.New("no SBOM file")
+
+// ErrEmptySBOM is returned by Parse when the document is valid but lists no
+// packages — a valid SBOM with nothing to check is treated distinctly from a
+// missing one.
+var ErrEmptySBOM = errors.New("SBOM contains no packages")
+
+// Load reads and parses the SBOM at path. It returns ErrNoSBOM (wrapped) when the
+// file is absent so callers can distinguish "no SBOM" from "bad SBOM".
+func Load(path string) ([]Package, error) {
+	data, err := os.ReadFile(path) // #nosec G304 — store-derived path
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("%w: %s", ErrNoSBOM, path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read SBOM %s: %w", path, err)
+	}
+	return parse(data, path)
+}
+
+// Parse decodes raw SBOM bytes (origin is used only for error messages).
+func Parse(raw []byte, origin string) ([]Package, error) { return parse(raw, origin) }
+
+func parse(data []byte, origin string) ([]Package, error) {
+	// Sniff the format by content. syft writes either SPDX-JSON (has "spdxVersion")
+	// or CycloneDX-JSON (has "bomFormat":"CycloneDX").
+	switch {
+	case bytes.Contains(data, []byte(`"spdxVersion"`)):
+		return parseSPDX(data, origin)
+	case bytes.Contains(data, []byte(`"bomFormat"`)) && bytes.Contains(data, []byte("CycloneDX")):
+		return parseCycloneDX(data, origin)
+	default:
+		return nil, fmt.Errorf("unrecognized SBOM format in %s (not SPDX-JSON or CycloneDX-JSON)", origin)
+	}
+}
+
+// --- SPDX-JSON ---------------------------------------------------------------
+
+type spdxDoc struct {
+	Packages []struct {
+		Name         string `json:"name"`
+		VersionInfo  string `json:"versionInfo"`
+		ExternalRefs []struct {
+			ReferenceType     string `json:"referenceType"`
+			ReferenceCategory string `json:"referenceCategory"`
+			ReferenceLocator  string `json:"referenceLocator"`
+		} `json:"externalRefs"`
+	} `json:"packages"`
+}
+
+func parseSPDX(data []byte, origin string) ([]Package, error) {
+	var doc spdxDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse SPDX SBOM %s: %w", origin, err)
+	}
+	var out []Package
+	for _, p := range doc.Packages {
+		pkg := Package{Name: p.Name, Version: p.VersionInfo}
+		for _, ref := range p.ExternalRefs {
+			if strings.EqualFold(ref.ReferenceType, "purl") {
+				pkg.PURL = ref.ReferenceLocator
+				pkg.Ecosystem = ecosystemFromPURL(ref.ReferenceLocator)
+				break
+			}
+		}
+		if pkg.Name == "" && pkg.PURL == "" {
+			continue
+		}
+		out = append(out, pkg)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("%w: %s", ErrEmptySBOM, origin)
+	}
+	return out, nil
+}
+
+// --- CycloneDX-JSON ----------------------------------------------------------
+
+type cycloneDoc struct {
+	Components []struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+		PURL    string `json:"purl"`
+	} `json:"components"`
+}
+
+func parseCycloneDX(data []byte, origin string) ([]Package, error) {
+	var doc cycloneDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse CycloneDX SBOM %s: %w", origin, err)
+	}
+	var out []Package
+	for _, c := range doc.Components {
+		if c.Name == "" && c.PURL == "" {
+			continue
+		}
+		out = append(out, Package{
+			Name:      c.Name,
+			Version:   c.Version,
+			PURL:      c.PURL,
+			Ecosystem: ecosystemFromPURL(c.PURL),
+		})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("%w: %s", ErrEmptySBOM, origin)
+	}
+	return out, nil
+}
+
+// ecosystemFromPURL maps a package URL's type to an OSV ecosystem name. Returns
+// "" when the purl is absent or the type is unmapped (the OSV query then falls
+// back to a purl-only query, which OSV resolves itself).
+func ecosystemFromPURL(purl string) string {
+	if !strings.HasPrefix(purl, "pkg:") {
+		return ""
+	}
+	rest := strings.TrimPrefix(purl, "pkg:")
+	typ := rest
+	if i := strings.IndexAny(rest, "/@"); i != -1 {
+		typ = rest[:i]
+	}
+	switch strings.ToLower(typ) {
+	case "golang":
+		return "Go"
+	case "npm":
+		return "npm"
+	case "pypi":
+		return "PyPI"
+	case "gem":
+		return "RubyGems"
+	case "cargo":
+		return "crates.io"
+	case "maven":
+		return "Maven"
+	case "nuget":
+		return "NuGet"
+	case "composer":
+		return "Packagist"
+	case "apk":
+		return "Alpine"
+	case "deb":
+		return "Debian"
+	default:
+		return ""
+	}
+}

--- a/internal/sbom/parse_test.go
+++ b/internal/sbom/parse_test.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package sbom_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/provabl/vet/internal/sbom"
+)
+
+func TestLoad_SPDX(t *testing.T) {
+	pkgs, err := sbom.Load("testdata/sample.spdx.json")
+	if err != nil {
+		t.Fatalf("Load SPDX: %v", err)
+	}
+	if len(pkgs) != 2 {
+		t.Fatalf("got %d packages, want 2: %+v", len(pkgs), pkgs)
+	}
+	// PURL preferred + ecosystem derived.
+	got := byName(pkgs)
+	if p := got["github.com/foo/bar"]; p.PURL != "pkg:golang/github.com/foo/bar@v1.2.3" || p.Ecosystem != "Go" || p.Version != "v1.2.3" {
+		t.Errorf("go package wrong: %+v", p)
+	}
+	if p := got["left-pad"]; p.Ecosystem != "npm" {
+		t.Errorf("npm package ecosystem = %q, want npm", p.Ecosystem)
+	}
+}
+
+func TestLoad_CycloneDX(t *testing.T) {
+	pkgs, err := sbom.Load("testdata/sample.cyclonedx.json")
+	if err != nil {
+		t.Fatalf("Load CycloneDX: %v", err)
+	}
+	if len(pkgs) != 2 {
+		t.Fatalf("got %d packages, want 2", len(pkgs))
+	}
+	got := byName(pkgs)
+	if p := got["requests"]; p.Ecosystem != "PyPI" || p.PURL != "pkg:pypi/requests@2.20.0" {
+		t.Errorf("pypi package wrong: %+v", p)
+	}
+}
+
+func TestLoad_AbsentIsErrNoSBOM(t *testing.T) {
+	_, err := sbom.Load(filepath.Join(t.TempDir(), "nope.spdx.json"))
+	if !errors.Is(err, sbom.ErrNoSBOM) {
+		t.Errorf("expected ErrNoSBOM, got %v", err)
+	}
+}
+
+func TestLoad_MalformedErrors(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "bad.spdx.json")
+	// Has the SPDX sniff marker but is invalid JSON.
+	if err := os.WriteFile(p, []byte(`{"spdxVersion":"SPDX-2.3" "packages"`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sbom.Load(p); err == nil {
+		t.Error("expected parse error for malformed SPDX")
+	}
+}
+
+func TestParse_UnknownFormat(t *testing.T) {
+	if _, err := sbom.Parse([]byte(`{"hello":"world"}`), "x.json"); err == nil {
+		t.Error("expected error for unrecognized SBOM format")
+	}
+}
+
+func TestParse_EmptyPackages(t *testing.T) {
+	_, err := sbom.Parse([]byte(`{"spdxVersion":"SPDX-2.3","packages":[]}`), "empty.json")
+	if !errors.Is(err, sbom.ErrEmptySBOM) {
+		t.Errorf("expected ErrEmptySBOM, got %v", err)
+	}
+}
+
+func byName(pkgs []sbom.Package) map[string]sbom.Package {
+	m := make(map[string]sbom.Package, len(pkgs))
+	for _, p := range pkgs {
+		m[p.Name] = p
+	}
+	return m
+}

--- a/internal/sbom/testdata/sample.cyclonedx.json
+++ b/internal/sbom/testdata/sample.cyclonedx.json
@@ -1,0 +1,8 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "components": [
+    {"type": "library", "name": "requests", "version": "2.20.0", "purl": "pkg:pypi/requests@2.20.0"},
+    {"type": "library", "name": "lodash", "version": "4.17.0", "purl": "pkg:npm/lodash@4.17.0"}
+  ]
+}

--- a/internal/sbom/testdata/sample.spdx.json
+++ b/internal/sbom/testdata/sample.spdx.json
@@ -1,0 +1,20 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "name": "sample",
+  "packages": [
+    {
+      "name": "github.com/foo/bar",
+      "versionInfo": "v1.2.3",
+      "externalRefs": [
+        {"referenceCategory": "PACKAGE-MANAGER", "referenceType": "purl", "referenceLocator": "pkg:golang/github.com/foo/bar@v1.2.3"}
+      ]
+    },
+    {
+      "name": "left-pad",
+      "versionInfo": "1.3.0",
+      "externalRefs": [
+        {"referenceCategory": "PACKAGE-MANAGER", "referenceType": "purl", "referenceLocator": "pkg:npm/left-pad@1.3.0"}
+      ]
+    }
+  ]
+}

--- a/internal/verify/cve_test.go
+++ b/internal/verify/cve_test.go
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package verify
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/provabl/vet/internal/store"
+)
+
+// stubTransport returns canned OSV responses keyed by whether the request body
+// names a package we want to flag. respFor is called per request body.
+type stubTransport struct {
+	respFor func(body string) (status int, json string)
+	calls   int
+}
+
+func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.calls++
+	b, _ := io.ReadAll(req.Body)
+	status, body := s.respFor(string(b))
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// newTestVerifier builds a Verifier with a temp store, a no-op Runner (so the
+// cosign/gh steps don't shell out), and an http.Client backed by the given OSV
+// stub transport.
+func newTestVerifier(t *testing.T, osv *stubTransport) (*Verifier, *store.Store) {
+	t.Helper()
+	s := store.New(t.TempDir())
+	v := NewWithRunner(stubRunner{}, s)
+	v.http = &http.Client{Transport: osv}
+	return v, s
+}
+
+type stubRunner struct{}
+
+// Run errors so verifySig/verifySLSA treat the artifact as unsigned / no
+// provenance — fine, these tests are about the CVE gate.
+func (stubRunner) Run(context.Context, string, ...string) ([]byte, error) {
+	return nil, os.ErrNotExist
+}
+
+// seedSPDX writes an SPDX SBOM with one package (purl) into the store for ref.
+func seedSPDX(t *testing.T, s *store.Store, ref, purl string) {
+	t.Helper()
+	if err := s.Init(); err != nil {
+		t.Fatal(err)
+	}
+	doc := `{"spdxVersion":"SPDX-2.3","packages":[{"name":"p","versionInfo":"1.0",` +
+		`"externalRefs":[{"referenceType":"purl","referenceLocator":"` + purl + `"}]}]}`
+	if err := os.WriteFile(s.SBOMPath(ref, "spdx"), []byte(doc), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const osvCritical = `{"vulns":[{"id":"GHSA-x","database_specific":{"severity":"CRITICAL"}}]}`
+const osvClean = `{}`
+
+func TestCheckCVEs_CriticalFlagged(t *testing.T) {
+	osv := &stubTransport{respFor: func(string) (int, string) { return 200, osvCritical }}
+	v, s := newTestVerifier(t, osv)
+	seedSPDX(t, s, "img:v1", "pkg:npm/left-pad@1.0.0")
+
+	crit, _, ran, err := v.checkCVEs(context.Background(), "img:v1")
+	if err != nil || !ran {
+		t.Fatalf("expected check to run cleanly, ran=%v err=%v", ran, err)
+	}
+	if !crit {
+		t.Error("expected CVECritical=true")
+	}
+	if osv.calls != 1 {
+		t.Errorf("expected 1 OSV call, got %d", osv.calls)
+	}
+}
+
+func TestCheckCVEs_CleanPasses(t *testing.T) {
+	osv := &stubTransport{respFor: func(string) (int, string) { return 200, osvClean }}
+	v, s := newTestVerifier(t, osv)
+	seedSPDX(t, s, "img:v1", "pkg:npm/safe@1.0.0")
+
+	crit, high, ran, err := v.checkCVEs(context.Background(), "img:v1")
+	if err != nil || !ran {
+		t.Fatalf("ran=%v err=%v", ran, err)
+	}
+	if crit || high {
+		t.Error("expected no critical/high for a clean package")
+	}
+}
+
+func TestCheckCVEs_NoSBOMDoesNotRun(t *testing.T) {
+	osv := &stubTransport{respFor: func(string) (int, string) { return 200, osvClean }}
+	v, _ := newTestVerifier(t, osv) // no SBOM seeded
+	_, _, ran, err := v.checkCVEs(context.Background(), "img:v1")
+	if ran {
+		t.Fatal("expected ran=false when no SBOM present")
+	}
+	if err == nil {
+		t.Fatal("expected an error explaining the missing SBOM")
+	}
+}
+
+func TestCheckCVEs_OSVErrorDoesNotRun(t *testing.T) {
+	osv := &stubTransport{respFor: func(string) (int, string) { return 503, "" }}
+	v, s := newTestVerifier(t, osv)
+	seedSPDX(t, s, "img:v1", "pkg:npm/x@1.0.0")
+	_, _, ran, err := v.checkCVEs(context.Background(), "img:v1")
+	if ran || err == nil {
+		t.Fatalf("expected fail-closed on OSV error: ran=%v err=%v", ran, err)
+	}
+}
+
+// The security regression: --check-cves with no SBOM must DENY, not silently pass.
+func TestVerify_CheckCVEsNoSBOMFailsClosed(t *testing.T) {
+	osv := &stubTransport{respFor: func(string) (int, string) { return 200, osvClean }}
+	v, _ := newTestVerifier(t, osv)
+
+	res, err := v.Verify(context.Background(), "img:v1", Options{CheckCVEs: "critical"})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if res.PolicyMet {
+		t.Fatal("SECURITY: --check-cves with no SBOM passed — must fail closed")
+	}
+	var found bool
+	for _, f := range res.Failures {
+		if strings.Contains(f, "CVE check requested but could not run") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a fail-closed CVE reason, got: %v", res.Failures)
+	}
+}
+
+// With a critical CVE in the SBOM, --check-cves critical must DENY.
+func TestVerify_CheckCVEsCriticalDenies(t *testing.T) {
+	osv := &stubTransport{respFor: func(string) (int, string) { return 200, osvCritical }}
+	v, s := newTestVerifier(t, osv)
+	seedSPDX(t, s, "img:v1", "pkg:npm/bad@1.0.0")
+
+	res, err := v.Verify(context.Background(), "img:v1", Options{CheckCVEs: "critical"})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if res.PolicyMet {
+		t.Fatal("expected DENY for an artifact with a critical CVE")
+	}
+	if !res.CVECritical {
+		t.Error("expected CVECritical=true")
+	}
+}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/provabl/vet/internal/sbom"
 	"github.com/provabl/vet/internal/store"
 )
 
@@ -109,19 +110,23 @@ func (v *Verifier) Verify(ctx context.Context, artifactRef string, opts Options)
 		}
 	}
 
-	// 3. SBOM presence + artifact hash (independent of the CVE check).
-	result.SBOMPresent = v.store.HasSBOM(artifactRef)
+	// 3. SBOM presence + artifact hash (independent of the CVE check). "Present"
+	// means a valid SBOM with at least one package — not merely a file on disk.
+	result.SBOMPresent = v.sbomPackages(artifactRef) != nil
 	result.ArtifactHash = artifactHash(artifactRef)
 
-	// 4. CVE check (requires SBOM in store)
+	// 4. CVE check. Fail-closed: if the operator asked for a CVE gate but it
+	// cannot be evaluated (no SBOM, unparseable, OSV unreachable), that is a
+	// policy failure — never a silent pass.
+	var cveErr error
 	if opts.CheckCVEs != "" {
-		sbomPath := v.store.SBOMPath(artifactRef, "spdx")
-		critical, high, cveErr := v.checkCVEs(ctx, sbomPath)
-		if cveErr == nil {
+		critical, high, ran, err := v.checkCVEs(ctx, artifactRef)
+		if ran {
 			result.CVECritical = critical
 			result.CVEHigh = high
+		} else {
+			cveErr = err // surfaced as a fail-closed policy failure below
 		}
-		// CVE check failure is non-blocking (SBOM may not exist yet)
 	}
 
 	// 5. Policy evaluation
@@ -132,6 +137,11 @@ func (v *Verifier) Verify(ctx context.Context, artifactRef string, opts Options)
 	if opts.MinSLSALevel > 0 && result.SLSALevel < opts.MinSLSALevel {
 		policyFailures = append(policyFailures,
 			fmt.Sprintf("SLSA level %d < minimum %d", result.SLSALevel, opts.MinSLSALevel))
+	}
+	if opts.CheckCVEs != "" && cveErr != nil {
+		// Fail closed: a requested CVE gate that could not run denies the artifact.
+		policyFailures = append(policyFailures,
+			fmt.Sprintf("CVE check requested but could not run: %v", cveErr))
 	}
 	switch opts.CheckCVEs {
 	case "critical":
@@ -246,14 +256,52 @@ func (v *Verifier) verifySLSA(ctx context.Context, ref, source string) (int, err
 	return extractSLSALevel(string(out)), nil
 }
 
-// checkCVEs queries the OSV API with packages extracted from an SBOM.
-func (v *Verifier) checkCVEs(_ context.Context, sbomPath string) (critical, high bool, err error) {
-	// Simplified: return false if SBOM not found. Full implementation reads SBOM
-	// packages and queries https://api.osv.dev/v1/querybatch.
-	if sbomPath == "" {
-		return false, false, fmt.Errorf("no SBOM path provided")
+// maxCVEPackages bounds how many SBOM packages a single verify will query against
+// OSV, so a pathologically large SBOM cannot wedge a run. If an SBOM exceeds it,
+// the check still runs over the first maxCVEPackages packages.
+const maxCVEPackages = 500
+
+// sbomPackages loads the parsed package list for an artifact, trying SPDX then
+// CycloneDX. Returns nil when no parseable, non-empty SBOM exists.
+func (v *Verifier) sbomPackages(artifactRef string) []sbom.Package {
+	for _, format := range []string{"spdx", "cyclonedx"} {
+		if pkgs, err := sbom.Load(v.store.SBOMPath(artifactRef, format)); err == nil && len(pkgs) > 0 {
+			return pkgs
+		}
 	}
-	return false, false, nil // non-fatal — CVE check deferred until SBOM present
+	return nil
+}
+
+// checkCVEs parses the artifact's SBOM and queries OSV for each package. The ran
+// return reports whether the check actually executed: when it is false the caller
+// must fail closed (a requested CVE gate that could not be evaluated must not pass).
+func (v *Verifier) checkCVEs(ctx context.Context, artifactRef string) (critical, high, ran bool, err error) {
+	pkgs := v.sbomPackages(artifactRef)
+	if pkgs == nil {
+		return false, false, false, fmt.Errorf("no SBOM present — run 'vet sbom %s' first", artifactRef)
+	}
+	if len(pkgs) > maxCVEPackages {
+		pkgs = pkgs[:maxCVEPackages]
+	}
+	var queried bool
+	for _, p := range pkgs {
+		c, h, qErr := queryOSV(ctx, v.http, p)
+		if qErr != nil {
+			// OSV unreachable mid-run: fail closed rather than under-report.
+			return false, false, false, fmt.Errorf("OSV query failed for %s: %w", pkgIdent(p), qErr)
+		}
+		queried = true
+		critical = critical || c
+		high = high || h
+	}
+	return critical, high, queried, nil
+}
+
+func pkgIdent(p sbom.Package) string {
+	if p.PURL != "" {
+		return p.PURL
+	}
+	return p.Name + "@" + p.Version
 }
 
 // --- helpers -----------------------------------------------------------------
@@ -295,12 +343,29 @@ func extractSLSALevel(ghOutput string) int {
 	return 0
 }
 
-// QueryOSV queries the OSV API for vulnerabilities matching a package.
-// Used by checkCVEs when SBOM parsing is implemented.
-func QueryOSV(ctx context.Context, client *http.Client, packageName, ecosystem string) (critical, high bool, err error) {
-	body := fmt.Sprintf(`{"package":{"name":%q,"ecosystem":%q}}`, packageName, ecosystem)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		"https://api.osv.dev/v1/query", bytes.NewBufferString(body))
+// osvQueryURL is the OSV single-package query endpoint. Unlike /v1/querybatch
+// (which returns only vuln IDs), /v1/query returns full vuln records including
+// severity inline, so a single call per package yields the CRITICAL/HIGH verdict.
+const osvQueryURL = "https://api.osv.dev/v1/query"
+
+// queryOSV asks OSV whether a single package has known critical/high
+// vulnerabilities. It queries by PURL when available (PURL encodes the
+// ecosystem), else by name+ecosystem. A malformed/empty response is treated as
+// "no known vulns"; a transport error is returned so the caller can fail closed.
+func queryOSV(ctx context.Context, client *http.Client, p sbom.Package) (critical, high bool, err error) {
+	var body string
+	switch {
+	case p.PURL != "":
+		body = fmt.Sprintf(`{"package":{"purl":%q}}`, p.PURL)
+	case p.Ecosystem != "":
+		body = fmt.Sprintf(`{"package":{"name":%q,"ecosystem":%q}}`, p.Name, p.Ecosystem)
+	default:
+		// Without a purl or ecosystem OSV cannot resolve the package; skip it
+		// rather than error (a bare name is ambiguous across ecosystems).
+		return false, false, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, osvQueryURL, bytes.NewBufferString(body))
 	if err != nil {
 		return false, false, err
 	}
@@ -309,8 +374,11 @@ func QueryOSV(ctx context.Context, client *http.Client, packageName, ecosystem s
 	if err != nil {
 		return false, false, err
 	}
-	defer resp.Body.Close()
-	data, _ := io.ReadAll(io.LimitReader(resp.Body, 512*1024))
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return false, false, fmt.Errorf("OSV returned status %d", resp.StatusCode)
+	}
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 
 	var result struct {
 		Vulns []struct {
@@ -318,17 +386,30 @@ func QueryOSV(ctx context.Context, client *http.Client, packageName, ecosystem s
 				Type  string `json:"type"`
 				Score string `json:"score"`
 			} `json:"severity"`
+			DatabaseSpecific struct {
+				Severity string `json:"severity"`
+			} `json:"database_specific"`
 		} `json:"vulns"`
 	}
 	if jsonErr := json.Unmarshal(data, &result); jsonErr != nil {
 		return false, false, nil
 	}
-	for _, v := range result.Vulns {
-		for _, s := range v.Severity {
-			if strings.Contains(s.Score, "CRITICAL") || strings.Contains(s.Type, "CRITICAL") {
+	for _, vuln := range result.Vulns {
+		// Some feeds carry a categorical severity (GHSA: "CRITICAL"/"HIGH"); CVSS
+		// feeds carry a vector score in Score. Check both.
+		sev := strings.ToUpper(vuln.DatabaseSpecific.Severity)
+		if sev == "CRITICAL" {
+			critical = true
+		}
+		if sev == "HIGH" {
+			high = true
+		}
+		for _, s := range vuln.Severity {
+			up := strings.ToUpper(s.Score + " " + s.Type)
+			if strings.Contains(up, "CRITICAL") {
 				critical = true
 			}
-			if strings.Contains(s.Score, "HIGH") || strings.Contains(s.Type, "HIGH") {
+			if strings.Contains(up, "HIGH") {
 				high = true
 			}
 		}


### PR DESCRIPTION
Closes #15 and #13. **Fixes the CVE false-pass security hole.**

## The hole (from the vet survey)
`vet verify --check-cves critical` was a **no-op**: `checkCVEs` returned hardcoded-clean, the gate keyed on those always-false values, and `QueryOSV` (a real OSV query) was orphaned. An artifact with critical CVEs **silently passed**.

## Fix
- **#15 — SBOM parsing** (`internal/sbom/parse.go`): parse syft's SPDX-JSON & CycloneDX-JSON into a package list, preferring **PURL** (encodes ecosystem) with name+version fallback. `SBOMPresent` now means *a valid SBOM with ≥1 package*, not *a file exists*. Distinct `ErrNoSBOM` / `ErrEmptySBOM` / parse errors.
- **#13 — real CVE check**: `checkCVEs` parses the SBOM and queries **OSV `/v1/query`** (severity inline) per package via the now-wired `queryOSV`; sets `CVECritical`/`CVEHigh` from real severities. A `ran` flag distinguishes *checked-clean* from *couldn't-check*.
- **Fail-closed** (the security fix): when `--check-cves` is requested but cannot run (no SBOM / unparseable / OSV unreachable), `Verify` records a policy failure → `PolicyMet=false`. Never a silent pass.

## Design
Pure stdlib — SBOM via `encoding/json` + minimal structs, OSV over the injected `http.Client`. **No new required CLI tool; go.mod gains no heavy deps.** `/v1/query` over `/v1/querybatch` because batch returns only IDs (severity needs an N+1 fetch); noted as a future optimization for very large SBOMs.

## Tests
- `internal/sbom`: SPDX / CycloneDX / absent (`ErrNoSBOM`) / malformed / empty (`ErrEmptySBOM`).
- `internal/verify` (stub OSV `RoundTripper` + seeded fixture SBOM): critical→deny, clean→pass, **no-SBOM→fail-closed**, OSV-error→fail-closed, plus the end-to-end **security regression** (`--check-cves` + no SBOM must DENY).

`go build/vet/test ./...` green. Note: `vet gate` consumes the verification record verify writes, so it benefits automatically once `vet verify` has run.

## Not in scope (separate issues)
#14 (SLSA-level heuristic), #16 (`gh` docs / silent-skip), OSV batch optimization.