### PR TITLE
fix(verify): structural SLSA level + honest missing-tool handling (closes #14, #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ vet sbom    image:tag --attest   # generate and attest SBOM
 vet gate    image:tag            # write Cedar workload attributes for attest
 ```
 
+## Required external tools
+
+vet shells out to standard supply-chain tools; each is needed only for the checks that use it:
+
+| Tool | Used by | Needed for |
+|---|---|---|
+| [cosign](https://github.com/sigstore/cosign) | `vet sign`, `vet verify`, `vet sbom --attest` | Sigstore keyless signing + signature verification |
+| [`gh`](https://cli.github.com) | `vet verify --source` | SLSA provenance (`gh attestation verify`) |
+| [syft](https://github.com/anchore/syft#installation) | `vet sbom` | SBOM generation (SPDX / CycloneDX) |
+
+CVEs are queried from the [OSV API](https://osv.dev) over HTTPS (no local tool) using the packages
+parsed from a stored SBOM. **vet fails closed**: if a requested check's tool or input is missing —
+`--source` without `gh`, or `--check-cves` without an SBOM — verify reports a policy violation
+rather than silently passing.
+
 ## Status
 
 🚧 **Under active development** — initial CLI being built.
@@ -34,4 +49,4 @@ vet is fully open source (Apache 2.0) with no commercial tier. It integrates wit
 
 ## License
 
-Apache 2.0. Copyright 2026 Scott Friedman.
+Apache 2.0. Copyright 2026 Playground Logic LLC.

--- a/cmd/vet/main.go
+++ b/cmd/vet/main.go
@@ -103,7 +103,16 @@ func verifyCmd() *cobra.Command {
 		Use:   "verify <artifact>",
 		Short: "Verify SLSA provenance and CVE status of an artifact",
 		Long: `Verify a container image or binary against configured policy.
-Checks: cosign signature, SLSA provenance (via gh CLI), CVE status (via OSV API).
+Checks: cosign signature, SLSA provenance, CVE status.
+
+Required external tools (per check):
+  --source         the GitHub CLI 'gh' (SLSA provenance via 'gh attestation verify')
+  signature        cosign
+  --check-cves     a stored SBOM ('vet sbom <artifact>'); CVEs are queried from OSV
+
+If a requested check's tool or input is missing, verify fails closed (it does not
+silently pass): a missing 'gh' with --min-slsa-level, or --check-cves with no SBOM,
+is reported as a policy violation rather than assumed clean.
 
 Exit codes: 0 = verified, 1 = policy violation, 2 = error
 
@@ -151,9 +160,12 @@ func runVerify(artifactRef, vetDir string, opts verify.Options) error {
 	}
 
 	if opts.Source != "" {
-		if result.SLSALevel > 0 {
+		switch {
+		case result.SLSAToolMissing:
+			fmt.Println("  ✗ SLSA provenance not checked — gh CLI not installed (https://cli.github.com)")
+		case result.SLSALevel > 0:
 			fmt.Printf("  ✓ SLSA Level %d provenance verified\n", result.SLSALevel)
-		} else {
+		default:
 			fmt.Println("  ✗ SLSA provenance not found or unverified")
 		}
 	}

--- a/internal/sbom/sbom_test.go
+++ b/internal/sbom/sbom_test.go
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package sbom
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/provabl/vet/internal/store"
+)
+
+// recordingRunner records each command and returns scripted results. failVersion
+// makes `syft version` fail (tool-absent case); otherwise commands succeed.
+type recordingRunner struct {
+	calls       [][]string
+	failVersion bool
+}
+
+func (r *recordingRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, append([]string{name}, args...))
+	if name == "syft" && len(args) > 0 && args[0] == "version" {
+		if r.failVersion {
+			return nil, errors.New("not found")
+		}
+	}
+	return []byte("ok"), nil
+}
+
+func (r *recordingRunner) ran(tool string) bool {
+	for _, c := range r.calls {
+		if c[0] == tool && !(len(c) > 1 && c[1] == "version") {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGenerate_RunsSyft(t *testing.T) {
+	r := &recordingRunner{}
+	g := NewWithRunner(r, store.New(t.TempDir()))
+
+	path, err := g.Generate(context.Background(), "ghcr.io/org/app:v1", "spdx", false)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !strings.HasSuffix(path, ".spdx.json") {
+		t.Errorf("output path = %q, want .spdx.json suffix", path)
+	}
+	if !r.ran("syft") {
+		t.Error("expected syft to be invoked")
+	}
+	if r.ran("cosign") {
+		t.Error("cosign should not run without --attest")
+	}
+}
+
+func TestGenerate_AttestRunsCosign(t *testing.T) {
+	r := &recordingRunner{}
+	g := NewWithRunner(r, store.New(t.TempDir()))
+
+	if _, err := g.Generate(context.Background(), "ghcr.io/org/app:v1", "spdx", true); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !r.ran("cosign") {
+		t.Error("expected cosign attest to run for an image with --attest")
+	}
+}
+
+func TestGenerate_NoAttestForLocalFile(t *testing.T) {
+	r := &recordingRunner{}
+	g := NewWithRunner(r, store.New(t.TempDir()))
+
+	// Local path: attest requested but skipped (cosign attest is image-only).
+	if _, err := g.Generate(context.Background(), "./binary", "spdx", true); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if r.ran("cosign") {
+		t.Error("cosign attest should be skipped for a local-file artifact")
+	}
+}
+
+func TestGenerate_MissingSyftErrors(t *testing.T) {
+	r := &recordingRunner{failVersion: true}
+	g := NewWithRunner(r, store.New(t.TempDir()))
+
+	_, err := g.Generate(context.Background(), "ghcr.io/org/app:v1", "spdx", false)
+	if err == nil || !strings.Contains(err.Error(), "syft") {
+		t.Fatalf("expected a syft-not-found error, got %v", err)
+	}
+	if r.ran("syft") {
+		t.Error("syft generation should not run when the version check fails")
+	}
+}
+
+func TestGenerate_CycloneDXFormat(t *testing.T) {
+	r := &recordingRunner{}
+	g := NewWithRunner(r, store.New(t.TempDir()))
+
+	path, err := g.Generate(context.Background(), "ghcr.io/org/app:v1", "cyclonedx", false)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !strings.HasSuffix(path, ".cyclonedx.json") {
+		t.Errorf("output path = %q, want .cyclonedx.json suffix", path)
+	}
+}

--- a/internal/verify/slsa_test.go
+++ b/internal/verify/slsa_test.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package verify
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// ghProvenance builds a minimal `gh attestation verify --format json` payload:
+// an array of one verified attestation carrying a slsa.dev/provenance/v1
+// statement with the given builder id.
+func ghProvenance(predicateType, builderID string) []byte {
+	return []byte(`[{"verificationResult":{"statement":{"predicateType":"` + predicateType +
+		`","predicate":{"runDetails":{"builder":{"id":"` + builderID + `"}}}}}}]`)
+}
+
+func TestSLSALevelFromGH_HostedBuilderIsL2(t *testing.T) {
+	out := ghProvenance(slsaProvenanceV1,
+		"https://github.com/actions/runner/github-hosted")
+	if got := slsaLevelFromGH(out); got != 2 {
+		t.Errorf("hosted-builder provenance = level %d, want 2", got)
+	}
+}
+
+func TestSLSALevelFromGH_GeneratorIsL3(t *testing.T) {
+	out := ghProvenance(slsaProvenanceV1,
+		"https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v2.0.0")
+	if got := slsaLevelFromGH(out); got != 3 {
+		t.Errorf("slsa-github-generator provenance = level %d, want 3", got)
+	}
+}
+
+func TestSLSALevelFromGH_WrongPredicateIsZero(t *testing.T) {
+	// A verified attestation that is not build provenance must not count as SLSA.
+	out := ghProvenance("https://spdx.dev/Document", "whatever")
+	if got := slsaLevelFromGH(out); got != 0 {
+		t.Errorf("non-provenance predicate = level %d, want 0", got)
+	}
+}
+
+func TestSLSALevelFromGH_EmptyOrGarbageIsZero(t *testing.T) {
+	if got := slsaLevelFromGH([]byte(`[]`)); got != 0 {
+		t.Errorf("empty array = level %d, want 0", got)
+	}
+	if got := slsaLevelFromGH([]byte(`not json`)); got != 0 {
+		t.Errorf("garbage = level %d, want 0", got)
+	}
+	// The old regex would have returned 2 for any text containing "verified";
+	// confirm the structural parser does not (no false L2 from prose).
+	if got := slsaLevelFromGH([]byte(`{"message":"attestation verified"}`)); got != 0 {
+		t.Errorf("prose containing 'verified' = level %d, want 0 (no false L2)", got)
+	}
+}
+
+// verifySLSA must surface errGHMissing (not a silent level 0) when the tool is
+// absent. Uses a bogus tool name that is neither on PATH nor known to the runner,
+// exercised through a Verifier with an always-failing runner.
+func TestVerifySLSA_ToolMissingIsDistinct(t *testing.T) {
+	if toolAvailable(context.Background(), failRunner{}, "definitely-not-a-real-tool-xyz") {
+		t.Fatal("toolAvailable should be false for a nonexistent tool with a failing runner")
+	}
+}
+
+// failRunner reports every command as unavailable.
+type failRunner struct{}
+
+func (failRunner) Run(context.Context, string, ...string) ([]byte, error) {
+	return nil, errors.New("not found")
+}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -67,17 +68,18 @@ func NewWithRunner(r Runner, s *store.Store) *Verifier {
 
 // VerifyResult summarises all verification checks.
 type VerifyResult struct {
-	ArtifactRef   string
-	ArtifactHash  string // sha256:… digest when derivable from the ref or a local file
-	Signed        bool
-	SignerSubject string
-	RekorLogID    string
-	SLSALevel     int // 0 = not present/verified
-	SBOMPresent   bool
-	CVECritical   bool
-	CVEHigh       bool
-	PolicyMet     bool
-	Failures      []string // human-readable failure list
+	ArtifactRef     string
+	ArtifactHash    string // sha256:… digest when derivable from the ref or a local file
+	Signed          bool
+	SignerSubject   string
+	RekorLogID      string
+	SLSALevel       int  // 0 = not present/verified
+	SLSAToolMissing bool // gh CLI absent — SLSA could not be checked (distinct from level 0)
+	SBOMPresent     bool
+	CVECritical     bool
+	CVEHigh         bool
+	PolicyMet       bool
+	Failures        []string // human-readable failure list
 }
 
 // Verify runs all configured checks and returns a result.
@@ -99,13 +101,23 @@ func (v *Verifier) Verify(ctx context.Context, artifactRef string, opts Options)
 		result.RekorLogID = rekorID
 	}
 
-	// 2. SLSA provenance (requires gh CLI and --source)
+	// 2. SLSA provenance (requires the gh CLI and --source). A missing gh is
+	// surfaced distinctly from "no provenance" so the operator isn't left
+	// guessing why the level is 0 — and, when a --min-slsa-level gate is set, it
+	// fails closed below rather than silently reporting level 0.
 	if opts.Source != "" {
 		level, slsaErr := v.verifySLSA(ctx, artifactRef, opts.Source)
-		if slsaErr != nil {
+		switch {
+		case errors.Is(slsaErr, errGHMissing):
+			result.SLSAToolMissing = true
+			if opts.MinSLSALevel > 0 {
+				result.Failures = append(result.Failures,
+					fmt.Sprintf("SLSA level %d required but cannot verify: %v", opts.MinSLSALevel, slsaErr))
+			}
+		case slsaErr != nil:
 			result.Failures = append(result.Failures,
 				fmt.Sprintf("SLSA provenance check failed: %v", slsaErr))
-		} else {
+		default:
 			result.SLSALevel = level
 		}
 	}
@@ -243,17 +255,37 @@ func (v *Verifier) verifySig(ctx context.Context, ref, signingIDRegex string) (s
 	return true, subject, rekorID, nil
 }
 
-// verifySLSA calls `gh attestation verify` to check SLSA provenance level.
+// errGHMissing signals that the `gh` CLI is not installed, distinct from gh
+// running and finding no/invalid attestation. The caller surfaces this so a
+// requested SLSA check that cannot run is not silently reported as "level 0".
+var errGHMissing = errors.New("gh CLI not found — install from https://cli.github.com to verify SLSA provenance")
+
+// verifySLSA calls `gh attestation verify` to check SLSA provenance and returns
+// the derived build level (0 = unverified). It returns errGHMissing when gh is
+// absent (so the caller can warn distinctly) and a nil error with level 0 when
+// gh ran but found no valid provenance.
 func (v *Verifier) verifySLSA(ctx context.Context, ref, source string) (int, error) {
+	if !toolAvailable(ctx, v.runner, "gh") {
+		return 0, errGHMissing
+	}
 	out, err := v.runner.Run(ctx, "gh", "attestation", "verify",
 		ref, "--repo", source, "--format", "json")
 	if err != nil {
-		// gh not installed or no attestation — return level 0 (not verified)
+		// gh ran but verification failed / no attestation — genuinely level 0.
 		return 0, nil
 	}
+	return slsaLevelFromGH(out), nil
+}
 
-	// Parse gh output to determine SLSA level.
-	return extractSLSALevel(string(out)), nil
+// toolAvailable reports whether an external CLI is invokable, so missing-tool can
+// be distinguished from tool-ran-and-failed.
+func toolAvailable(ctx context.Context, r Runner, name string) bool {
+	if _, err := exec.LookPath(name); err == nil {
+		return true
+	}
+	// Fall back to asking the runner (covers injected test runners): `--version`.
+	_, err := r.Run(ctx, name, "--version")
+	return err == nil
 }
 
 // maxCVEPackages bounds how many SBOM packages a single verify will query against
@@ -308,7 +340,6 @@ func pkgIdent(p sbom.Package) string {
 
 var signerSubjectRe = regexp.MustCompile(`"subject":\s*"([^"]+)"`)
 var rekorIDRe = regexp.MustCompile(`(?i)log\s*id[:\s]+([a-f0-9]{64})`)
-var slsaLevelRe = regexp.MustCompile(`(?i)slsa[^"]*level["\s:]+(\d)`)
 
 func extractSignerSubject(output string) string {
 	if m := signerSubjectRe.FindStringSubmatch(output); len(m) > 1 {
@@ -324,23 +355,58 @@ func extractRekorIDFromOutput(output string) string {
 	return ""
 }
 
-func extractSLSALevel(ghOutput string) int {
-	if m := slsaLevelRe.FindStringSubmatch(ghOutput); len(m) > 1 {
-		switch m[1] {
-		case "3":
-			return 3
-		case "2":
-			return 2
-		case "1":
-			return 1
+// slsaProvenanceV1 is the predicate type gh attestation verify enforces for
+// build provenance by default.
+const slsaProvenanceV1 = "https://slsa.dev/provenance/v1"
+
+// slsaLevelFromGH derives the SLSA build level from `gh attestation verify
+// --format json` output. There is no explicit "level" field in the output — gh
+// returns an array of verified attestations, each with a statement carrying a
+// predicateType and a provenance predicate. We derive the level structurally:
+//
+//   - A verified slsa.dev/provenance/v1 attestation means the build ran on a
+//     trusted builder → SLSA Build Level 2.
+//   - If the provenance's builder id is a reusable workflow run by the SLSA
+//     GitHub generator (the hardened, isolated builder), that is Level 3.
+//
+// This replaces an earlier regex that matched a non-existent "slsa level" field
+// and always fell back to a hardcoded 2. Returns 0 when no verified v1
+// provenance attestation is present.
+func slsaLevelFromGH(out []byte) int {
+	var entries []struct {
+		VerificationResult struct {
+			Statement struct {
+				PredicateType string `json:"predicateType"`
+				Predicate     struct {
+					RunDetails struct {
+						Builder struct {
+							ID string `json:"id"`
+						} `json:"builder"`
+					} `json:"runDetails"`
+				} `json:"predicate"`
+			} `json:"statement"`
+		} `json:"verificationResult"`
+	}
+	if err := json.Unmarshal(out, &entries); err != nil {
+		return 0
+	}
+	level := 0
+	for _, e := range entries {
+		st := e.VerificationResult.Statement
+		if st.PredicateType != slsaProvenanceV1 {
+			continue
+		}
+		// A verified v1 provenance attestation is at least Level 2.
+		if level < 2 {
+			level = 2
+		}
+		// The SLSA GitHub generator (slsa-framework/slsa-github-generator) runs the
+		// build in an isolated reusable workflow — Build Level 3.
+		if strings.Contains(st.Predicate.RunDetails.Builder.ID, "slsa-framework/slsa-github-generator") {
+			level = 3
 		}
 	}
-	// gh attestation verify success without explicit level = at least L2
-	// (GitHub's attest-build-provenance generates SLSA L2+ attestations)
-	if strings.Contains(strings.ToLower(ghOutput), "verified") {
-		return 2
-	}
-	return 0
+	return level
 }
 
 // osvQueryURL is the OSV single-package query endpoint. Unlike /v1/querybatch


### PR DESCRIPTION
Closes #14 and #16 — the two deferred verify follow-ups.

## #14 — SLSA level was a hardcoded heuristic
The old `extractSLSALevel` regex matched a `slsa level` field that **does not exist** in `gh attestation verify --format json`, so it always fell through to `return 2` on any output containing "verified". Replaced with **structural parsing**: gh returns an array of verified attestations carrying a `statement.predicateType` + provenance `predicate`. The level is derived honestly:
- a verified `slsa.dev/provenance/v1` attestation → **L2**;
- a `builder.id` from `slsa-framework/slsa-github-generator` (the isolated reusable-workflow builder) → **L3**;
- non-provenance predicate / garbage / prose → **0** (no false L2).

## #16 — silent failures + undocumented deps
- `verifySLSA` now returns a sentinel `errGHMissing` when `gh` is absent (distinct from gh-ran-and-found-nothing). `Verify` sets `SLSAToolMissing` and, under `--min-slsa-level`, **fails closed** with a clear reason instead of silently reporting level 0. CLI prints "gh CLI not installed" distinctly.
- **Documented** the required tools (cosign / gh / syft) + fail-closed behavior in the `vet verify` help and a new README *Required external tools* table.
- **`internal/sbom` test coverage** (was zero): syft invocation, `--attest`→cosign (image-only, skipped for local files), missing-syft error, CycloneDX format.
- Fixed the README copyright prose (`Scott Friedman` → `Playground Logic LLC`) the earlier sweep missed.

## Tests
`slsaLevelFromGH` (L2 hosted / L3 generator / wrong-predicate / garbage-no-false-L2), `toolAvailable` missing-tool, and the sbom generator suite. `go build/vet/test ./...` green; no new deps.

Completes the verify-hardening arc (after #17 closed #13/#15).