### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-09
+
 ### Added
 
 - **Verdict produced through the provabl/evidence kernel** (#9): `vet gate` now appraises via the
@@ -64,6 +66,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - **`vet.provabl.dev`** documentation site (GitHub Pages).
 - Test coverage: sign, verify, store, gate with mock runner interface.
 
-[Unreleased]: https://github.com/provabl/vet/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/provabl/vet/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/provabl/vet/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/provabl/vet/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/provabl/vet/releases/tag/v0.1.0

--- a/cmd/vet/main.go
+++ b/cmd/vet/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/provabl/vet/internal/verify"
 )
 
-var version = "0.1.1"
+var version = "0.2.0"
 
 func main() {
 	if err := rootCmd().Execute(); err != nil {


### PR DESCRIPTION
Release prep for vet v0.2.0 (minor bump — pre-1.0, new features + the L3 pilot).

Promotes `[Unreleased]` → `[0.2.0]`, bumps `main.version`, adds the compare link.

Headline changes since v0.1.1:
- **Security**: `vet verify --check-cves` was a silent no-op that passed vulnerable artifacts — now real OSV checking, fail-closed (#13/#15).
- Real SBOM parsing (SPDX/CycloneDX → package list) (#15).
- Gate verdict routed through the provabl/evidence kernel (#9).
- Structural SLSA-level parsing; missing-`gh` surfaced distinctly (#14/#16).
- **SLSA L3 release pilot** (provabl#5) — this tag's release run produces the first real L3 provenance.

Merging this, then tagging `v0.2.0` triggers the release workflow.