### PR TITLE
ci: bump actions to Node-24 runtimes; fix RELEASING.md verification

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -84,7 +84,7 @@ jobs:
           echo "hashes=${HASHES}" >> "$GITHUB_OUTPUT"
 
       - name: Upload release assets (binaries + signatures)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/*
@@ -116,12 +116,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -146,7 +146,7 @@ jobs:
           sbom-path: vet-${{ steps.version.outputs.VERSION }}.spdx.json
 
       - name: Upload SBOM to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: vet-${{ steps.version.outputs.VERSION }}.spdx.json
           fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ## [Unreleased]
 
+### Changed
+
+- **CI/release actions bumped to Node-24 runtimes**: `actions/checkout@v4→v6`,
+  `actions/setup-go@v5→v6`, `softprops/action-gh-release@v2→v3` — clears the GitHub Node-20
+  deprecation warnings for the actions we control. (Warnings from the slsa-github-generator's
+  internal actions are upstream and clear when it ships past v2.1.0.)
+
+### Fixed
+
+- **`RELEASING.md` verification steps**: the provenance file is `multiple.intoto.jsonl` (one file
+  for all binaries), not a per-binary `.intoto.jsonl`; and `gh attestation verify` does not work
+  for the generic generator's release-asset provenance (404) — `slsa-verifier verify-artifact` is
+  the correct consumer check. Verified against the v0.2.0 release.
+
 ## [0.2.0] - 2026-06-09
 
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,11 +47,14 @@ git push origin vX.Y.Z
 
 ### Verify SLSA L3 provenance with `slsa-verifier`
 
+The generic generator publishes **one** provenance file, `multiple.intoto.jsonl`, that attests all
+the release binaries together (not one `.intoto.jsonl` per binary).
+
 ```bash
 # Install: go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@latest
 slsa-verifier verify-artifact \
   vet-vX.Y.Z-linux-amd64 \
-  --provenance-path vet-vX.Y.Z-linux-amd64.intoto.jsonl \
+  --provenance-path multiple.intoto.jsonl \
   --source-uri github.com/provabl/vet \
   --source-tag vX.Y.Z
 # → PASSED: SLSA verification passed
@@ -59,13 +62,18 @@ slsa-verifier verify-artifact \
 
 `slsa-verifier` confirms the provenance was produced by the trusted
 slsa-github-generator builder (the L3 builder identity), that the artifact hash
-matches, and that the source repo/tag are as expected.
+matches, and that the source repo/tag are as expected. Verified on v0.2.0:
 
-You can also inspect the provenance with `gh`:
-
-```bash
-gh attestation verify vet-vX.Y.Z-linux-amd64 --repo provabl/vet
 ```
+Verified build using builder ".../generator_generic_slsa3.yml@refs/tags/v2.1.0" at commit <sha>
+Verifying artifact vet-v0.2.0-darwin-arm64: PASSED
+PASSED: SLSA verification passed
+```
+
+> **Not `gh attestation verify`.** The generic generator uploads provenance as a **release asset**
+> (`multiple.intoto.jsonl`), not to GitHub's attestations API — so `gh attestation verify … --repo
+> provabl/vet` returns HTTP 404. `slsa-verifier verify-artifact` (above) is the correct consumer
+> check.
 
 ### Verify the cosign signature
 


### PR DESCRIPTION
Clears the GitHub **Node-20 deprecation warnings** for the actions we control (seen in the v0.2.0 release run):

| Action | Was | Now | Runtime |
|---|---|---|---|
| actions/checkout | v4 | v6 | node24 |
| actions/setup-go | v5 | v6 | node24 |
| softprops/action-gh-release | v2 | v3 | node24 (runtime-only major — no input/API change per upstream notes) |

`sigstore/cosign-installer` and `actions/attest-sbom` are composite (unaffected); `anchore/sbom-action@v0` already resolves to a Node-24 build.

**Not fixable here:** the remaining warnings in a release run come from the `slsa-github-generator`'s *internal* actions (`detect-workflow-js@v2.1.0`, its pinned checkout/setup-go/upload-artifact). Those live inside the reusable workflow and clear when the generator ships a release past v2.1.0.

Also fixes **RELEASING.md**, caught while verifying the real v0.2.0 release: provenance is `multiple.intoto.jsonl` (one file for all binaries), and `gh attestation verify` 404s for the generic generator's release-asset provenance — `slsa-verifier verify-artifact` is the correct consumer check.