### PR TITLE
feat(preflight): vet preflight verifies the caller's IAM permissions (provabl#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
+- **`vet preflight`** (provabl#16): verifies the calling principal holds the IAM action vet's AMI
+  vetter needs (`ec2:CreateTags`) via read-only `iam:SimulatePrincipalPolicy` against the caller ARN.
+  Renders ✓/✗ per action with remediation; exits non-zero on any deny; fail-closed on an un-callable
+  check. New `internal/preflight` (mock-driven tests). Mirrors attest/ground; each suite tool carries
+  its own copy (the kernel is the only shared dep). See `docs/required-permissions.md`.
 - **AMI vetting** (provabl#13, slice 2): `vet gate ami-… --tag-vetted` writes the `attest:vetted=true`
   tag to an AWS AMI via the EC2 API when the gate passes — the producer for ground's AMI-launch-gating
   SCP (which permits `ec2:RunInstances` only for AMIs carrying that tag). Fail-closed: a failing gate

--- a/cmd/vet/main.go
+++ b/cmd/vet/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/provabl/vet/internal/amitag"
 	"github.com/provabl/vet/internal/gate"
+	"github.com/provabl/vet/internal/preflight"
 	"github.com/provabl/vet/internal/sbom"
 	"github.com/provabl/vet/internal/sign"
 	"github.com/provabl/vet/internal/store"
@@ -41,8 +42,48 @@ Where qualify qualifies the person, vet qualifies the software.
   vet gate    image:tag            # write Cedar workload attributes for attest`,
 		Version: version,
 	}
-	cmd.AddCommand(signCmd(), verifyCmd(), sbomCmd(), gateCmd())
+	cmd.AddCommand(signCmd(), verifyCmd(), sbomCmd(), gateCmd(), preflightCmd())
 	return cmd
+}
+
+// preflightCmd verifies the calling principal holds the IAM actions vet needs.
+func preflightCmd() *cobra.Command {
+	var region string
+	cmd := &cobra.Command{
+		Use:   "preflight",
+		Short: "Verify the calling principal holds the IAM permissions vet needs",
+		Long: `Check that the calling AWS principal can perform vet's AWS-touching actions
+(the AMI vetter's ec2:CreateTags), via read-only iam:SimulatePrincipalPolicy
+against the caller — it evaluates, it does not act. A denied action prints a
+remediation and the command exits non-zero. See docs/required-permissions.md.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runPreflight(preflight.CheckCallerPermissions(cmd.Context(), region))
+		},
+	}
+	cmd.Flags().StringVar(&region, "region", "us-east-1", "AWS region")
+	return cmd
+}
+
+// runPreflight renders preflight results and returns a non-nil error if any failed.
+func runPreflight(results []preflight.Result) error {
+	failures := 0
+	for _, r := range results {
+		if r.Status {
+			fmt.Printf("  ✓ %s\n", r.Name)
+			continue
+		}
+		failures++
+		fmt.Printf("  ✗ %s: %s\n", r.Name, r.Detail)
+		if r.Remediation != "" {
+			fmt.Printf("      Remediation: %s\n", r.Remediation)
+		}
+	}
+	fmt.Println()
+	if failures > 0 {
+		return fmt.Errorf("preflight failed: %d required permission(s) missing", failures)
+	}
+	fmt.Println("✓ All required permissions present")
+	return nil
 }
 
 // ── sign ──────────────────────────────────────────────────────────────────────

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.307.0
+	github.com/aws/aws-sdk-go-v2/service/iam v1.54.4
+	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
 	github.com/provabl/evidence v0.1.0
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
@@ -22,7 +24,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.2.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.31.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.6 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3 // indirect
 	github.com/aws/smithy-go v1.27.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30 h1:VTGy885W5DKBxWRUJbym9hytNaY
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30/go.mod h1:AS0HycUvJRFvTt613AYDOgO2jzw+00cVSMny8XB3yMY=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.307.0 h1:ZQMhFWDFhwJbq3xCggO0gh3AW+yu65QtcT9F5HfdZhY=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.307.0/go.mod h1:8mrDF7OtbuL0QpwP4YCvLuoOE4/5lL7D33MXgp069/Y=
+github.com/aws/aws-sdk-go-v2/service/iam v1.54.4 h1:V5Fl1MjjTCuC6PUsHOVWEbI5kMg0MP5Xsxw9fHX94V8=
+github.com/aws/aws-sdk-go-v2/service/iam v1.54.4/go.mod h1:tMNzI+fYFCk4cIdZ7FEybLzShwnmWkfxQw85ED1b4ng=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 h1:ZD2+BSw9vFsNlKYIasSNt3uDbjqqXIBcM13UJv/Lx2k=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12/go.mod h1:Ms4zlcVBbXbiP7EVLhl+lgjvA/a7YphqQ3Ih3174EmI=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29 h1:DRebniUGZ2MqiiIVmQJ04vIXr918hubdHMnarSLEWyU=

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package preflight verifies that the calling AWS principal holds the IAM actions
+// vet needs for its AWS-touching operations. It uses read-only
+// iam:SimulatePrincipalPolicy against the caller ARN (from sts:GetCallerIdentity) —
+// it evaluates, it never acts. This catches an under-permissioned account up front,
+// before an operation fails mid-way.
+//
+// It mirrors attest's and ground's caller-permission check (provabl#16). The suite
+// tools are deliberately decoupled — the evidence kernel is the only shared
+// dependency, and it is stdlib-only — so each tool carries its own small copy of
+// this generic check rather than introducing a shared AWS-SDK library. The per-tool
+// action lists are documented in the suite's docs/required-permissions.md.
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// Result is the outcome of one permission check.
+type Result struct {
+	Name        string // the action, e.g. "ec2:CreateTags"
+	Severity    string // "ok" | "error"
+	Status      bool   // true when the action is permitted
+	Detail      string // what was found
+	Remediation string // actionable step when Status is false
+}
+
+type stsIdentityAPI interface {
+	GetCallerIdentity(ctx context.Context, in *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
+
+type iamSimAPI interface {
+	SimulatePrincipalPolicy(ctx context.Context, in *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error)
+}
+
+// vetRequiredActions are the AWS IAM actions vet needs. vet's container/binary
+// verification shells out to cosign/gh/syft + the OSV HTTP API (no AWS); its one
+// AWS-touching operation is the AMI vetter (`vet gate ami-… --tag-vetted`), which
+// writes attest:vetted via ec2:CreateTags. iam:SimulatePrincipalPolicy is included
+// because this preflight itself needs it. See docs/required-permissions.md.
+var vetRequiredActions = []string{
+	"sts:GetCallerIdentity",
+	"iam:SimulatePrincipalPolicy",
+	"ec2:CreateTags",
+}
+
+// CheckCallerPermissions loads AWS config for the region and verifies the calling
+// principal holds vet's required actions. Fail-closed: a config/credential failure
+// is an error result, not a silent pass.
+func CheckCallerPermissions(ctx context.Context, region string) []Result {
+	if region == "" {
+		region = "us-east-1"
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		return []Result{{
+			Name: "AWS credentials", Severity: "error", Status: false,
+			Detail:      err.Error(),
+			Remediation: "Configure AWS credentials: aws configure or set AWS_PROFILE",
+		}}
+	}
+	return check(ctx, sts.NewFromConfig(cfg), iam.NewFromConfig(cfg))
+}
+
+func check(ctx context.Context, stsSvc stsIdentityAPI, iamSvc iamSimAPI) []Result {
+	ident, err := stsSvc.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return []Result{{
+			Name: "Caller identity", Severity: "error", Status: false,
+			Detail:      fmt.Sprintf("sts:GetCallerIdentity failed: %v", err),
+			Remediation: "Ensure valid AWS credentials with sts:GetCallerIdentity",
+		}}
+	}
+	callerARN := aws.ToString(ident.Arn)
+
+	out, err := iamSvc.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: aws.String(callerARN),
+		ActionNames:     vetRequiredActions,
+	})
+	if err != nil {
+		return []Result{{
+			Name: "IAM permission self-check", Severity: "error", Status: false,
+			Detail:      fmt.Sprintf("iam:SimulatePrincipalPolicy failed for %s: %v", callerARN, err),
+			Remediation: "Grant iam:SimulatePrincipalPolicy to run the preflight (or review required-permissions.md manually)",
+		}}
+	}
+
+	var results []Result
+	for _, ev := range out.EvaluationResults {
+		action := aws.ToString(ev.EvalActionName)
+		if ev.EvalDecision == iamtypes.PolicyEvaluationDecisionTypeAllowed {
+			results = append(results, Result{Name: action, Severity: "ok", Status: true, Detail: "allowed"})
+			continue
+		}
+		results = append(results, Result{
+			Name: action, Severity: "error", Status: false,
+			Detail:      fmt.Sprintf("%s for %s", string(ev.EvalDecision), callerARN),
+			Remediation: "Grant " + action + " to the vet principal (see required-permissions.md)",
+		})
+	}
+	if len(results) == 0 {
+		return []Result{{
+			Name: "IAM permission self-check", Severity: "error", Status: false,
+			Detail:      "simulator returned no evaluation results",
+			Remediation: "Review required-permissions.md and the vet principal's policy",
+		}}
+	}
+	return results
+}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+type mockSTS struct {
+	arn string
+	err error
+}
+
+func (m mockSTS) GetCallerIdentity(_ context.Context, _ *sts.GetCallerIdentityInput, _ ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &sts.GetCallerIdentityOutput{Arn: aws.String(m.arn)}, nil
+}
+
+type mockIAMSim struct {
+	denied map[string]bool
+	err    error
+}
+
+func (m mockIAMSim) SimulatePrincipalPolicy(_ context.Context, in *iam.SimulatePrincipalPolicyInput, _ ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	var results []iamtypes.EvaluationResult
+	for _, a := range in.ActionNames {
+		dec := iamtypes.PolicyEvaluationDecisionTypeAllowed
+		if m.denied[a] {
+			dec = iamtypes.PolicyEvaluationDecisionTypeExplicitDeny
+		}
+		results = append(results, iamtypes.EvaluationResult{EvalActionName: aws.String(a), EvalDecision: dec})
+	}
+	return &iam.SimulatePrincipalPolicyOutput{EvaluationResults: results}, nil
+}
+
+const testARN = "arn:aws:iam::942542972736:role/vet-runner"
+
+func allOK(rs []Result) bool {
+	for _, r := range rs {
+		if !r.Status {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCheck_AllAllowed(t *testing.T) {
+	rs := check(context.Background(), mockSTS{arn: testARN}, mockIAMSim{})
+	if len(rs) != len(vetRequiredActions) {
+		t.Fatalf("expected %d results, got %d", len(vetRequiredActions), len(rs))
+	}
+	if !allOK(rs) {
+		t.Error("expected all actions allowed → all ok")
+	}
+}
+
+// A denied action surfaces as a non-ok result with remediation (fail-closed).
+func TestCheck_DeniedActionIsError(t *testing.T) {
+	target := vetRequiredActions[len(vetRequiredActions)-1] // the tool-specific action
+	rs := check(context.Background(), mockSTS{arn: testARN}, mockIAMSim{denied: map[string]bool{target: true}})
+	var found bool
+	for _, r := range rs {
+		if r.Name == target {
+			found = true
+			if r.Status || r.Severity != "error" || r.Remediation == "" {
+				t.Errorf("denied action = %+v; want non-ok error with remediation", r)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no result for the denied action %q", target)
+	}
+	if allOK(rs) {
+		t.Error("a denied action must make the set not-all-ok")
+	}
+}
+
+func TestCheck_CallerIdentityErrorFailsClosed(t *testing.T) {
+	rs := check(context.Background(), mockSTS{err: errors.New("ExpiredToken")}, mockIAMSim{})
+	if len(rs) != 1 || rs[0].Status {
+		t.Fatalf("expected one error result on GetCallerIdentity failure, got %+v", rs)
+	}
+}
+
+func TestCheck_SimulatorErrorFailsClosed(t *testing.T) {
+	rs := check(context.Background(), mockSTS{arn: testARN}, mockIAMSim{err: errors.New("AccessDenied")})
+	if len(rs) != 1 || rs[0].Status {
+		t.Fatalf("expected one fail-closed error result on simulator failure, got %+v", rs)
+	}
+	if rs[0].Remediation == "" {
+		t.Error("fail-closed result should explain how to enable the self-check")
+	}
+}


### PR DESCRIPTION
Rolls the caller-permission preflight (the attest/ground pattern) to **vet**. `vet preflight` simulates the actions vet needs against the caller ARN via read-only `iam:SimulatePrincipalPolicy` — allowed → ✓, denied → ✗ + remediation, fail-closed on an un-callable check, exits non-zero on any deny. New `internal/preflight` + mock-driven tests (allowed/denied/both fail-closed paths). Duplicated rather than shared, preserving the suite's decoupling. Verified live where applicable.

Refs: provabl#16