### PR TITLE
ci: add Security Scan workflow (govulncheck + Trivy fs + IaC)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,46 @@
+name: Security Scan
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 8 * * 1' # Weekly Monday 8am UTC
+
+permissions:
+  contents: read
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # --- Go vulnerability check (reachability-aware) ---
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
+      # --- Trivy filesystem scan (dependencies, by presence) ---
+      - name: Trivy filesystem scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: HIGH,CRITICAL
+          exit-code: 1
+
+      # --- Trivy IaC / config scan ---
+      - name: Trivy IaC scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: config
+          scan-ref: .
+          severity: HIGH,CRITICAL
+          exit-code: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
+
+- **Added a `Security Scan` workflow** (`.github/workflows/security.yml`): govulncheck + Trivy filesystem (dependency) + Trivy IaC scans on every push/PR and weekly, blocking on HIGH/CRITICAL. Trivy pinned to `v0.36.0`. Brings this repo in line with the rest of the suite — every Provabl tool now self-scans, fitting a security/compliance suite.
 - **`vet ami-reference`** (provabl#13): records a vetted AMI's known-good boot measurements as locked
   `attest:pcr<N>` tags (`--pcr <index>=<hex>`, repeatable), so a running instance can be bound to the
   vetted image — the kernel appraisers already check `expected_pcr<N>`. NitroTPM/enclave PCRs can't be


### PR DESCRIPTION
Brings **vet** in line with the rest of the suite: every Provabl tool should self-scan — it's a security/compliance suite, yet only attest had a security workflow.

## What
Adds the standard `.github/workflows/security.yml`:
- **govulncheck** — reachability-aware Go vulnerability scan
- **Trivy filesystem** — dependency CVEs (HIGH/CRITICAL, blocking)
- **Trivy IaC/config** — misconfig scan (HIGH/CRITICAL, blocking)

On push to main, every PR, and weekly. **Trivy pinned to `v0.36.0`** — not `@master` (the drift that broke attest's scan, fixed in attest#118).

## Verified before shipping
Local `trivy fs` and `trivy config` scans **exit 0** on this repo (clean) — so this goes green on first run, no surprise red. (The x/crypto CVEs that the suite-wide sweep surfaced are already resolved.)

Consolidated the standalone govulncheck job out of `ci.yaml` into this workflow (no longer duplicated).

Part of the suite-wide security-workflow rollout.