### PR TITLE
docs: add Mermaid boundary diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Part of the [Provabl](https://provabl.dev) suite:
 vet verifies software artifacts before they are permitted to access sensitive data in
 an SRE. Where qualify qualifies the *person*, vet qualifies the *software*.
 
+```mermaid
+flowchart LR
+    art["artifact / AMI<br/>(image, binary)"] --> vet["<b>vet</b><br/>sign · SLSA · SBOM · CVE"]
+    vet --> gate[".vet/gate-result.json"]
+    vet --> amitag["attest:vetted / attest:pcr&lt;N&gt; tags"]
+    gate -->|"context.workload.*"| attest["<b>attest</b><br/>Cedar PDP"]
+    amitag -->|"gated by"| scp["<b>ground</b> AMI SCP"]
+```
+
 ```bash
 vet sign    image:tag            # sign artifact via Sigstore keyless
 vet verify  image:tag            # verify SLSA provenance + CVE status


### PR DESCRIPTION
Adds a **boundary diagram** to `vet`'s README — the audit's most consistent gap (no tool had one) and the highest-leverage visual for evaluators.

Shows vet's inputs → what it does → the lowered attribute it produces → who consumes it, per the suite's [per-tool doc template](https://github.com/provabl/provabl/blob/main/docs/guide/per-tool-template.md). GitHub-native Mermaid (no binary asset); render-checked (balanced fences, escaped `&amp;`/`&lt;`). Docs-only.