### PR TITLE
docs: extend the tagline to five verbs — add steward your data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 vet is the software supply chain layer of the Provabl suite.
 It verifies software artifacts before they can access sensitive data in an SRE.
 
-**Tagline**: ground your infrastructure, attest your controls, qualify your people, vet your software.
+**Tagline**: ground your infrastructure, attest your controls, qualify your people, vet your software, steward your data.
 
 ## What vet does
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Part of the [Provabl](https://provabl.dev) suite:
 - **[qualify](https://qualify.provabl.dev)** — train and qualify researchers
 - **vet** — vet your software ← you are here
 
-> Ground your infrastructure, attest your controls, qualify your people, vet your software.
+> Ground your infrastructure, attest your controls, qualify your people, vet your software, steward your data.
 
 ---
 


### PR DESCRIPTION
steward is now a shipped tool, so the suite tagline gains a fifth verb.

Extends the four-verb tagline to five — `steward your data` — in both casings:
- `CLAUDE.md` (lowercase "ground … steward your data")
- `README.md` (capital "Ground … steward your data")

Leaves vet's own row in the README suite list (`vet — vet your software ← you are here`) untouched.