### PR TITLE
feat: pluggable CVE-scanning seam (internal/cve) — vet#32 slice 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
+- **`internal/cve` — a pluggable CVE-scanning seam** (provabl/vet#32, slice 1): extracted CVE scanning
+  behind a `cve.Source` interface (`Scan(ctx, []sbom.Package) (Verdict, error)`), with the existing
+  per-package OSV query as the default `OSVSource`. The Verifier delegates to a configurable source
+  (`WithCVESource`), defaulting to OSV — no behaviour change for container/binary SBOMs. This is the
+  foundation for AMI deep-content scanning: a live both-source test (commented on vet#32) showed the
+  two viable AMI sources have *different* sharp edges — Amazon Inspector (managed, ALAS-native, but
+  billable + gated on a managed/agentless instance) vs. EBS-snapshot→syft→distro-matcher (self-contained,
+  but a **naive OSV `Linux` query returns false-clean for Amazon Linux packages** because OSV's `Linux`
+  ecosystem is upstream-kernel-scoped, not ALAS-aware) — so CVE scanning is now a strategy, not a
+  hardcoded call. The OSV source honestly reports unresolvable (bare-name) packages as *scanned: 0*
+  rather than passing them. Fail-closed preserved (a source that can't evaluate denies). The `inspector`
+  and `snapshot+grype` AMI sources land in follow-up slices.
 
 - **Added a `Security Scan` workflow** (`.github/workflows/security.yml`): govulncheck + Trivy filesystem (dependency) + Trivy IaC scans on every push/PR and weekly, blocking on HIGH/CRITICAL. Trivy pinned to `v0.36.0`. Brings this repo in line with the rest of the suite — every Provabl tool now self-scans, fitting a security/compliance suite.
 - **`vet ami-reference`** (provabl#13): records a vetted AMI's known-good boot measurements as locked

--- a/internal/cve/cve.go
+++ b/internal/cve/cve.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cve defines the pluggable CVE-scanning seam: a Source takes the
+// packages identified for an artifact and returns whether any have known
+// critical/high vulnerabilities. The default Source queries OSV per package
+// (the path vet has always used for container/binary SBOMs).
+//
+// The seam exists because an AMI is a different scanning problem than a language
+// artifact, and a live both-source test (provabl/vet#32) showed the two viable
+// AMI sources have different sharp edges:
+//   - Amazon Inspector — managed, ALAS-native, but billable and gated on the
+//     instance being Inspector-managed (or agentless EBS-snapshot scanning).
+//   - EBS snapshot → syft → a distro-aware matcher — self-contained, on-demand,
+//     but a NAIVE OSV "Linux" query returns false-clean for Amazon Linux packages
+//     (OSV's Linux ecosystem is upstream-kernel-scoped, not ALAS-aware).
+//
+// So CVE scanning is a strategy, not a hardcoded call. This package is the
+// interface + the default OSV Source; the AMI sources (inspector, snapshot+grype)
+// register as additional Sources in their own slices.
+package cve
+
+import (
+	"context"
+
+	"github.com/provabl/vet/internal/sbom"
+)
+
+// Verdict is the outcome of a CVE scan: whether any scanned package carries a
+// known critical/high vulnerability. It is intentionally coarse — it matches the
+// CVECritical/CVEHigh booleans the gate and the context.workload.* contract use.
+// Scanned reports how many packages were actually evaluated, so a caller can tell
+// a genuine clean result from one where nothing was checked.
+type Verdict struct {
+	Critical bool
+	High     bool
+	Scanned  int
+}
+
+// Source scans the given packages for known vulnerabilities. A Source must
+// fail closed: if it cannot evaluate the packages (database unreachable, an
+// ecosystem it cannot resolve when the caller demanded a verdict), it returns a
+// non-nil error rather than a falsely-clean Verdict. Returning a clean Verdict
+// means "evaluated, and nothing critical/high was found."
+//
+// pkgs is the identified package set for the artifact (from an SBOM, or — for an
+// AMI source — enumerated off the image). The Source decides how to match them to
+// advisories; that matching is the whole point of the seam.
+type Source interface {
+	// Name identifies the source for logs and records, e.g. "osv".
+	Name() string
+	// Scan evaluates pkgs and returns the critical/high verdict.
+	Scan(ctx context.Context, pkgs []sbom.Package) (Verdict, error)
+}

--- a/internal/cve/osv.go
+++ b/internal/cve/osv.go
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package cve
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/provabl/vet/internal/sbom"
+)
+
+// osvQueryURL is the OSV single-package query endpoint. Unlike /v1/querybatch
+// (which returns only vuln IDs), /v1/query returns full vuln records including
+// severity inline, so a single call per package yields the CRITICAL/HIGH verdict.
+const osvQueryURL = "https://api.osv.dev/v1/query"
+
+// maxOSVPackages bounds how many packages a single scan will query against OSV,
+// so a pathologically large SBOM cannot wedge a run. If the set exceeds it, the
+// scan still runs over the first maxOSVPackages packages.
+const maxOSVPackages = 500
+
+// OSVSource is the default CVE Source: it queries OSV's free API per package.
+// It is the path vet has always used for container/binary SBOMs — packages with
+// a PURL or an OSV ecosystem (npm, Go, PyPI, …). It is NOT distro-advisory aware:
+// Amazon Linux / RHEL packages keyed only by name resolve to nothing useful in
+// OSV's "Linux" ecosystem, which is why AMI scanning needs a different Source
+// (see package doc + provabl/vet#32).
+type OSVSource struct {
+	client *http.Client
+}
+
+// NewOSVSource returns an OSVSource. A nil client gets a default 30s-timeout one.
+func NewOSVSource(client *http.Client) *OSVSource {
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &OSVSource{client: client}
+}
+
+// Name identifies the source.
+func (*OSVSource) Name() string { return "osv" }
+
+// Scan queries OSV for each package and returns the aggregate critical/high
+// verdict. Fail-closed: a transport error mid-scan returns an error (the caller
+// must not pass), rather than under-reporting. A package OSV cannot resolve (no
+// PURL, no ecosystem) is skipped — a bare name is ambiguous across ecosystems —
+// but counted as not-scanned so the caller can see coverage.
+func (s *OSVSource) Scan(ctx context.Context, pkgs []sbom.Package) (Verdict, error) {
+	if len(pkgs) > maxOSVPackages {
+		pkgs = pkgs[:maxOSVPackages]
+	}
+	var v Verdict
+	for _, p := range pkgs {
+		c, h, resolvable, err := queryOSV(ctx, s.client, p)
+		if err != nil {
+			return Verdict{}, fmt.Errorf("OSV query failed for %s: %w", pkgIdent(p), err)
+		}
+		if !resolvable {
+			continue
+		}
+		v.Scanned++
+		v.Critical = v.Critical || c
+		v.High = v.High || h
+	}
+	return v, nil
+}
+
+func pkgIdent(p sbom.Package) string {
+	if p.PURL != "" {
+		return p.PURL
+	}
+	return p.Name + "@" + p.Version
+}
+
+// queryOSV asks OSV whether a single package has known critical/high
+// vulnerabilities. It queries by PURL when available (PURL encodes the
+// ecosystem), else by name+ecosystem. resolvable reports whether OSV could be
+// queried for the package at all (false when it has neither a PURL nor an
+// ecosystem). A malformed/empty response is treated as "no known vulns"; a
+// transport error is returned so the caller can fail closed.
+func queryOSV(ctx context.Context, client *http.Client, p sbom.Package) (critical, high, resolvable bool, err error) {
+	var body string
+	switch {
+	case p.PURL != "":
+		body = fmt.Sprintf(`{"package":{"purl":%q}}`, p.PURL)
+	case p.Ecosystem != "":
+		body = fmt.Sprintf(`{"package":{"name":%q,"ecosystem":%q}}`, p.Name, p.Ecosystem)
+	default:
+		return false, false, false, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, osvQueryURL, bytes.NewBufferString(body))
+	if err != nil {
+		return false, false, false, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, false, false, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return false, false, false, fmt.Errorf("OSV returned status %d", resp.StatusCode)
+	}
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+
+	var result struct {
+		Vulns []struct {
+			Severity []struct {
+				Type  string `json:"type"`
+				Score string `json:"score"`
+			} `json:"severity"`
+			DatabaseSpecific struct {
+				Severity string `json:"severity"`
+			} `json:"database_specific"`
+		} `json:"vulns"`
+	}
+	if jsonErr := json.Unmarshal(data, &result); jsonErr != nil {
+		return false, false, true, nil
+	}
+	for _, vuln := range result.Vulns {
+		// Some feeds carry a categorical severity (GHSA: "CRITICAL"/"HIGH"); CVSS
+		// feeds carry a vector score in Score. Check both.
+		sev := strings.ToUpper(vuln.DatabaseSpecific.Severity)
+		if sev == "CRITICAL" {
+			critical = true
+		}
+		if sev == "HIGH" {
+			high = true
+		}
+		for _, sc := range vuln.Severity {
+			up := strings.ToUpper(sc.Score + " " + sc.Type)
+			if strings.Contains(up, "CRITICAL") {
+				critical = true
+			}
+			if strings.Contains(up, "HIGH") {
+				high = true
+			}
+		}
+	}
+	return critical, high, true, nil
+}

--- a/internal/cve/osv_test.go
+++ b/internal/cve/osv_test.go
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package cve
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/provabl/vet/internal/sbom"
+)
+
+// stubTransport returns a canned OSV response (or status) per request.
+type stubTransport struct {
+	respFor func(body string) (status int, json string)
+	calls   int
+}
+
+func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.calls++
+	b, _ := io.ReadAll(req.Body)
+	status, body := s.respFor(string(b))
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func osvSourceWith(tr *stubTransport) *OSVSource {
+	return NewOSVSource(&http.Client{Transport: tr})
+}
+
+const (
+	osvCritical = `{"vulns":[{"id":"GHSA-x","database_specific":{"severity":"CRITICAL"}}]}`
+	osvHigh     = `{"vulns":[{"id":"GHSA-y","database_specific":{"severity":"HIGH"}}]}`
+	osvClean    = `{}`
+)
+
+func TestOSV_Name(t *testing.T) {
+	if NewOSVSource(nil).Name() != "osv" {
+		t.Error("Name() should be osv")
+	}
+}
+
+func TestOSV_CriticalFlagged(t *testing.T) {
+	tr := &stubTransport{respFor: func(string) (int, string) { return 200, osvCritical }}
+	v, err := osvSourceWith(tr).Scan(context.Background(), []sbom.Package{{PURL: "pkg:npm/left-pad@1.0.0"}})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if !v.Critical {
+		t.Error("expected Critical")
+	}
+	if v.Scanned != 1 {
+		t.Errorf("Scanned = %d, want 1", v.Scanned)
+	}
+}
+
+func TestOSV_HighFlagged(t *testing.T) {
+	tr := &stubTransport{respFor: func(string) (int, string) { return 200, osvHigh }}
+	v, _ := osvSourceWith(tr).Scan(context.Background(), []sbom.Package{{PURL: "pkg:npm/x@1.0.0"}})
+	if v.Critical || !v.High {
+		t.Errorf("expected High only, got %+v", v)
+	}
+}
+
+func TestOSV_CleanPasses(t *testing.T) {
+	tr := &stubTransport{respFor: func(string) (int, string) { return 200, osvClean }}
+	v, err := osvSourceWith(tr).Scan(context.Background(), []sbom.Package{{PURL: "pkg:npm/safe@1.0.0"}})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if v.Critical || v.High {
+		t.Error("clean package should not flag")
+	}
+	if v.Scanned != 1 {
+		t.Errorf("Scanned = %d, want 1", v.Scanned)
+	}
+}
+
+// A transport error mid-scan must fail closed (error, not a clean verdict).
+func TestOSV_TransportErrorFailsClosed(t *testing.T) {
+	tr := &stubTransport{respFor: func(string) (int, string) { return 503, "" }}
+	_, err := osvSourceWith(tr).Scan(context.Background(), []sbom.Package{{PURL: "pkg:npm/x@1.0.0"}})
+	if err == nil {
+		t.Fatal("expected fail-closed error on OSV 503")
+	}
+}
+
+// A package with neither PURL nor ecosystem is unresolvable: skipped, not scanned,
+// and not an error. This is exactly the AMI/distro gap (a bare rpm name) — the
+// OSV source honestly reports it scanned nothing rather than falsely passing it.
+func TestOSV_UnresolvablePackageSkipped(t *testing.T) {
+	tr := &stubTransport{respFor: func(string) (int, string) { return 200, osvClean }}
+	v, err := osvSourceWith(tr).Scan(context.Background(), []sbom.Package{{Name: "bash", Version: "5.2.15"}})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if v.Scanned != 0 {
+		t.Errorf("Scanned = %d, want 0 (bare name is unresolvable in OSV)", v.Scanned)
+	}
+	if tr.calls != 0 {
+		t.Errorf("expected no OSV calls for an unresolvable package, got %d", tr.calls)
+	}
+}
+
+func TestOSV_ByEcosystem(t *testing.T) {
+	tr := &stubTransport{respFor: func(string) (int, string) { return 200, osvCritical }}
+	v, _ := osvSourceWith(tr).Scan(context.Background(), []sbom.Package{{Name: "django", Version: "3.0", Ecosystem: "PyPI"}})
+	if !v.Critical || v.Scanned != 1 {
+		t.Errorf("ecosystem-keyed package should scan + flag, got %+v", v)
+	}
+}
+
+func TestOSV_AggregatesAcrossPackages(t *testing.T) {
+	// First package clean, second critical → aggregate Critical, Scanned 2.
+	tr := &stubTransport{respFor: func(body string) (int, string) {
+		if strings.Contains(body, "bad") {
+			return 200, osvCritical
+		}
+		return 200, osvClean
+	}}
+	v, err := osvSourceWith(tr).Scan(context.Background(), []sbom.Package{
+		{PURL: "pkg:npm/safe@1.0.0"},
+		{PURL: "pkg:npm/bad@1.0.0"},
+	})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if !v.Critical || v.Scanned != 2 {
+		t.Errorf("expected Critical with Scanned=2, got %+v", v)
+	}
+}

--- a/internal/verify/cve_test.go
+++ b/internal/verify/cve_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/provabl/vet/internal/cve"
 	"github.com/provabl/vet/internal/store"
 )
 
@@ -39,7 +40,11 @@ func newTestVerifier(t *testing.T, osv *stubTransport) (*Verifier, *store.Store)
 	t.Helper()
 	s := store.New(t.TempDir())
 	v := NewWithRunner(stubRunner{}, s)
-	v.http = &http.Client{Transport: osv}
+	client := &http.Client{Transport: osv}
+	v.http = client
+	// Point the CVE source at the same stub transport so checkCVEs delegates to a
+	// fake OSV (the seam keeps the existing OSV behaviour as the default source).
+	v.WithCVESource(cve.NewOSVSource(client))
 	return v, s
 }
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -6,7 +6,6 @@
 package verify
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -20,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/provabl/vet/internal/cve"
 	"github.com/provabl/vet/internal/sbom"
 	"github.com/provabl/vet/internal/store"
 )
@@ -50,20 +50,34 @@ type Verifier struct {
 	runner Runner
 	store  *store.Store
 	http   *http.Client
+	// cveSource scans the artifact's packages for known vulnerabilities. Defaults
+	// to OSV (the path for container/binary SBOMs); an AMI target swaps in a
+	// distro-aware source (provabl/vet#32).
+	cveSource cve.Source
 }
 
 // New creates a Verifier.
 func New(s *store.Store) *Verifier {
+	client := &http.Client{Timeout: 30 * time.Second}
 	return &Verifier{
-		runner: &defaultRunner{},
-		store:  s,
-		http:   &http.Client{Timeout: 30 * time.Second},
+		runner:    &defaultRunner{},
+		store:     s,
+		http:      client,
+		cveSource: cve.NewOSVSource(client),
 	}
 }
 
 // NewWithRunner creates a Verifier with a custom runner (for testing).
 func NewWithRunner(r Runner, s *store.Store) *Verifier {
-	return &Verifier{runner: r, store: s, http: &http.Client{Timeout: 30 * time.Second}}
+	client := &http.Client{Timeout: 30 * time.Second}
+	return &Verifier{runner: r, store: s, http: client, cveSource: cve.NewOSVSource(client)}
+}
+
+// WithCVESource overrides the CVE source (the AMI sources, or a test fake) and
+// returns the Verifier for chaining.
+func (v *Verifier) WithCVESource(src cve.Source) *Verifier {
+	v.cveSource = src
+	return v
 }
 
 // VerifyResult summarises all verification checks.
@@ -288,11 +302,6 @@ func toolAvailable(ctx context.Context, r Runner, name string) bool {
 	return err == nil
 }
 
-// maxCVEPackages bounds how many SBOM packages a single verify will query against
-// OSV, so a pathologically large SBOM cannot wedge a run. If an SBOM exceeds it,
-// the check still runs over the first maxCVEPackages packages.
-const maxCVEPackages = 500
-
 // sbomPackages loads the parsed package list for an artifact, trying SPDX then
 // CycloneDX. Returns nil when no parseable, non-empty SBOM exists.
 func (v *Verifier) sbomPackages(artifactRef string) []sbom.Package {
@@ -304,36 +313,22 @@ func (v *Verifier) sbomPackages(artifactRef string) []sbom.Package {
 	return nil
 }
 
-// checkCVEs parses the artifact's SBOM and queries OSV for each package. The ran
-// return reports whether the check actually executed: when it is false the caller
-// must fail closed (a requested CVE gate that could not be evaluated must not pass).
+// checkCVEs loads the artifact's SBOM and delegates to the configured CVE source.
+// The ran return reports whether the check actually executed: when it is false the
+// caller must fail closed (a requested CVE gate that could not be evaluated must
+// not pass). The scanning strategy itself lives in internal/cve — OSV by default,
+// a distro-aware source for AMIs (provabl/vet#32).
 func (v *Verifier) checkCVEs(ctx context.Context, artifactRef string) (critical, high, ran bool, err error) {
 	pkgs := v.sbomPackages(artifactRef)
 	if pkgs == nil {
 		return false, false, false, fmt.Errorf("no SBOM present — run 'vet sbom %s' first", artifactRef)
 	}
-	if len(pkgs) > maxCVEPackages {
-		pkgs = pkgs[:maxCVEPackages]
+	verdict, scanErr := v.cveSource.Scan(ctx, pkgs)
+	if scanErr != nil {
+		// Source could not evaluate (DB unreachable, …): fail closed.
+		return false, false, false, scanErr
 	}
-	var queried bool
-	for _, p := range pkgs {
-		c, h, qErr := queryOSV(ctx, v.http, p)
-		if qErr != nil {
-			// OSV unreachable mid-run: fail closed rather than under-report.
-			return false, false, false, fmt.Errorf("OSV query failed for %s: %w", pkgIdent(p), qErr)
-		}
-		queried = true
-		critical = critical || c
-		high = high || h
-	}
-	return critical, high, queried, nil
-}
-
-func pkgIdent(p sbom.Package) string {
-	if p.PURL != "" {
-		return p.PURL
-	}
-	return p.Name + "@" + p.Version
+	return verdict.Critical, verdict.High, true, nil
 }
 
 // --- helpers -----------------------------------------------------------------
@@ -407,78 +402,4 @@ func slsaLevelFromGH(out []byte) int {
 		}
 	}
 	return level
-}
-
-// osvQueryURL is the OSV single-package query endpoint. Unlike /v1/querybatch
-// (which returns only vuln IDs), /v1/query returns full vuln records including
-// severity inline, so a single call per package yields the CRITICAL/HIGH verdict.
-const osvQueryURL = "https://api.osv.dev/v1/query"
-
-// queryOSV asks OSV whether a single package has known critical/high
-// vulnerabilities. It queries by PURL when available (PURL encodes the
-// ecosystem), else by name+ecosystem. A malformed/empty response is treated as
-// "no known vulns"; a transport error is returned so the caller can fail closed.
-func queryOSV(ctx context.Context, client *http.Client, p sbom.Package) (critical, high bool, err error) {
-	var body string
-	switch {
-	case p.PURL != "":
-		body = fmt.Sprintf(`{"package":{"purl":%q}}`, p.PURL)
-	case p.Ecosystem != "":
-		body = fmt.Sprintf(`{"package":{"name":%q,"ecosystem":%q}}`, p.Name, p.Ecosystem)
-	default:
-		// Without a purl or ecosystem OSV cannot resolve the package; skip it
-		// rather than error (a bare name is ambiguous across ecosystems).
-		return false, false, nil
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, osvQueryURL, bytes.NewBufferString(body))
-	if err != nil {
-		return false, false, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := client.Do(req)
-	if err != nil {
-		return false, false, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return false, false, fmt.Errorf("OSV returned status %d", resp.StatusCode)
-	}
-	data, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-
-	var result struct {
-		Vulns []struct {
-			Severity []struct {
-				Type  string `json:"type"`
-				Score string `json:"score"`
-			} `json:"severity"`
-			DatabaseSpecific struct {
-				Severity string `json:"severity"`
-			} `json:"database_specific"`
-		} `json:"vulns"`
-	}
-	if jsonErr := json.Unmarshal(data, &result); jsonErr != nil {
-		return false, false, nil
-	}
-	for _, vuln := range result.Vulns {
-		// Some feeds carry a categorical severity (GHSA: "CRITICAL"/"HIGH"); CVSS
-		// feeds carry a vector score in Score. Check both.
-		sev := strings.ToUpper(vuln.DatabaseSpecific.Severity)
-		if sev == "CRITICAL" {
-			critical = true
-		}
-		if sev == "HIGH" {
-			high = true
-		}
-		for _, s := range vuln.Severity {
-			up := strings.ToUpper(s.Score + " " + s.Type)
-			if strings.Contains(up, "CRITICAL") {
-				critical = true
-			}
-			if strings.Contains(up, "HIGH") {
-				high = true
-			}
-		}
-	}
-	return critical, high, nil
 }


### PR DESCRIPTION
First slice of **vet#32** (AMI deep-content scanning). Pure refactor + foundation — no behaviour change, no AWS.

## Why

A live both-source test ([vet#32 comment](https://github.com/provabl/vet/issues/32#issuecomment-4803827591)) on a real AL2023 instance showed the two viable AMI CVE sources have *different* sharp edges:
- **Amazon Inspector** — managed, ALAS-native, but billable and gated on the instance being Inspector-managed (or agentless EBS-snapshot scanning).
- **EBS snapshot → syft → matcher** — self-contained, on-demand, but a **naive OSV `Linux` query returns false-clean** for Amazon Linux packages (OSV's `Linux` ecosystem is upstream-kernel-scoped, not ALAS-aware).

So CVE scanning should be a *strategy*, not a hardcoded OSV call. This slice introduces the seam they plug into.

## What

- **New `internal/cve`**: a `Source` interface — `Scan(ctx, []sbom.Package) (Verdict, error)` — and the existing per-package OSV query moved verbatim into the default `OSVSource`.
- **`verify.Verifier`** gains a `cveSource` field (defaults to OSV) and `WithCVESource(...)`. `checkCVEs` now loads the SBOM and delegates to the source.
- **No behaviour change** for container/binary SBOMs: the existing `verify` CVE tests pass through the seam unchanged.
- The OSV source reports unresolvable bare-name packages as `Scanned: 0` (not a false pass) — the honest version of the OSV-Linux≠ALAS gap. **Fail-closed preserved**: a source that can't evaluate returns an error and the gate denies.

## Tests

- New `internal/cve/osv_test.go`: critical / high / clean / transport-fail-closed / unresolvable-bare-name / by-ecosystem / multi-package aggregation.
- Existing `internal/verify` CVE tests unchanged and green.

## Next slices

`inspector` source (agentless EBS scan, ALAS-native) and `snapshot+grype` source (distro-aware matcher), each behind this interface; both need live AWS so they'll follow the suite pattern (injectable interfaces + fakes in CI, live wiring manual).

> Note: `gofmt` flags `internal/sign/sign.go` on the current toolchain — pre-existing drift, not touched by this PR.