### PR TITLE
feat: distro-aware CVE source (grype) for AMIs — vet#32 slice 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
+- **`cve.GrypeSource` — distro-aware CVE scanning for AMIs** (provabl/vet#32, slice 2): a second
+  `cve.Source` that scans the **SBOM document** with grype (anchore/grype), which is distro-advisory
+  aware (matches Amazon Linux / RHEL / Debian packages against their security feeds, e.g. Amazon ALAS)
+  — fixing the false-clean gap the live test found, where a naive OSV `Linux` query reports a distro
+  AMI as clean. `vet verify` gains `--cve-source auto|osv|grype` (default `auto`): an `ami-…` target
+  routes to grype, everything else to OSV; an explicit value overrides. The `cve.Source` interface now
+  takes a `Target{Packages, SBOMPath}` — the second implementer revealed one input shape doesn't fit
+  both: OSV queries `Packages`, grype consumes the full `SBOMPath` document (the package list drops the
+  distro metadata grype needs). grype is **fail-closed**: a missing SBOM path, absent grype binary,
+  non-zero exit, or unparseable output all deny rather than pass. New `result.CVECheckRan` so the CLI
+  no longer prints "✓ No critical/high CVEs" when the check actually failed to run. The live AWS wiring
+  (EBS-snapshot → syft) is the next slice; this slice is fully fake-tested (no AWS).
+
 - **`internal/cve` — a pluggable CVE-scanning seam** (provabl/vet#32, slice 1): extracted CVE scanning
   behind a `cve.Source` interface (`Scan(ctx, []sbom.Package) (Verdict, error)`), with the existing
   per-package OSV query as the default `OSVSource`. The Verifier delegates to a configurable source

--- a/cmd/vet/cve_source_test.go
+++ b/cmd/vet/cve_source_test.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "testing"
+
+func TestResolveCVESource(t *testing.T) {
+	cases := []struct {
+		name    string
+		flag    string
+		ref     string
+		want    string // expected Source.Name()
+		wantErr bool
+	}{
+		{"auto routes AMI to grype", "auto", "ami-0abc123", "grype", false},
+		{"auto routes image to osv", "auto", "ghcr.io/org/img:v1", "osv", false},
+		{"empty defaults like auto (AMI)", "", "ami-0abc123", "grype", false},
+		{"explicit osv on an AMI", "osv", "ami-0abc123", "osv", false},
+		{"explicit grype on an image", "grype", "ghcr.io/org/img:v1", "grype", false},
+		{"unknown source errors", "trivy", "ami-0abc123", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src, err := resolveCVESource(tc.flag, tc.ref)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if src.Name() != tc.want {
+				t.Errorf("source = %q, want %q", src.Name(), tc.want)
+			}
+		})
+	}
+}

--- a/cmd/vet/main.go
+++ b/cmd/vet/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/provabl/vet/internal/amitag"
+	"github.com/provabl/vet/internal/cve"
 	"github.com/provabl/vet/internal/gate"
 	"github.com/provabl/vet/internal/preflight"
 	"github.com/provabl/vet/internal/sbom"
@@ -142,6 +143,7 @@ func verifyCmd() *cobra.Command {
 	var checkCVEs string
 	var signingID string
 	var vetDir string
+	var cveSource string
 
 	cmd := &cobra.Command{
 		Use:   "verify <artifact>",
@@ -166,7 +168,11 @@ Examples:
   vet verify ./binary --source github.com/org/repo`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runVerify(args[0], vetDir, verify.Options{
+			src, err := resolveCVESource(cveSource, args[0])
+			if err != nil {
+				return err
+			}
+			return runVerify(args[0], vetDir, src, verify.Options{
 				Source:         source,
 				MinSLSALevel:   minSLSA,
 				CheckCVEs:      checkCVEs,
@@ -179,12 +185,33 @@ Examples:
 	cmd.Flags().StringVar(&checkCVEs, "check-cves", "", "fail on CVEs at or above: critical, high, medium")
 	cmd.Flags().StringVar(&signingID, "signing-id-regexp", "", "certificate-identity-regexp for cosign")
 	cmd.Flags().StringVar(&vetDir, "vet-dir", ".vet", ".vet directory path")
+	cmd.Flags().StringVar(&cveSource, "cve-source", "auto",
+		"CVE scanner: auto (grype for AMIs, osv otherwise), osv, or grype (distro-aware, needs the grype binary)")
 	return cmd
 }
 
-func runVerify(artifactRef, vetDir string, opts verify.Options) error {
+// resolveCVESource picks the CVE scanner. "auto" routes AMI targets to grype
+// (distro-advisory aware — a naive OSV query is false-clean on a distro AMI,
+// provabl/vet#32) and everything else to OSV; an explicit name overrides.
+func resolveCVESource(name, artifactRef string) (cve.Source, error) {
+	switch name {
+	case "osv":
+		return cve.NewOSVSource(nil), nil
+	case "grype":
+		return cve.NewGrypeSource(), nil
+	case "auto", "":
+		if isAMIRef(artifactRef) {
+			return cve.NewGrypeSource(), nil
+		}
+		return cve.NewOSVSource(nil), nil
+	default:
+		return nil, fmt.Errorf("unknown --cve-source %q (want: auto, osv, grype)", name)
+	}
+}
+
+func runVerify(artifactRef, vetDir string, cveSrc cve.Source, opts verify.Options) error {
 	s := store.New(vetDir)
-	v := verify.New(s)
+	v := verify.New(s).WithCVESource(cveSrc)
 
 	fmt.Printf("Verifying %s...\n", artifactRef)
 	result, err := v.Verify(contextWithTimeout(), artifactRef, opts)
@@ -223,9 +250,10 @@ func runVerify(artifactRef, vetDir string, opts verify.Options) error {
 			}
 		case result.CVEHigh:
 			fmt.Println("  ✗ High CVEs found")
-		case !result.SBOMPresent:
-			// The CVE gate could not run; the policy violation below explains it.
-			fmt.Println("  ✗ CVE check could not run (no SBOM)")
+		case !result.CVECheckRan:
+			// The CVE gate could not run (no SBOM, scanner missing, DB unreachable);
+			// the policy violation below explains the specific reason.
+			fmt.Println("  ✗ CVE check could not run")
 		default:
 			fmt.Println("  ✓ No critical/high CVEs found")
 		}

--- a/internal/cve/cve.go
+++ b/internal/cve/cve.go
@@ -26,29 +26,43 @@ import (
 	"github.com/provabl/vet/internal/sbom"
 )
 
-// Verdict is the outcome of a CVE scan: whether any scanned package carries a
-// known critical/high vulnerability. It is intentionally coarse — it matches the
+// Verdict is the outcome of a CVE scan: whether the artifact carries a known
+// critical/high vulnerability. It is intentionally coarse — it matches the
 // CVECritical/CVEHigh booleans the gate and the context.workload.* contract use.
-// Scanned reports how many packages were actually evaluated, so a caller can tell
-// a genuine clean result from one where nothing was checked.
+// Scanned reports how many units (packages, or vuln matches) were actually
+// evaluated, so a caller can tell a genuine clean result from one where nothing
+// was checked.
 type Verdict struct {
 	Critical bool
 	High     bool
 	Scanned  int
 }
 
-// Source scans the given packages for known vulnerabilities. A Source must
-// fail closed: if it cannot evaluate the packages (database unreachable, an
-// ecosystem it cannot resolve when the caller demanded a verdict), it returns a
-// non-nil error rather than a falsely-clean Verdict. Returning a clean Verdict
-// means "evaluated, and nothing critical/high was found."
+// Target is what a Source scans. Different sources consume different parts of it —
+// the second implementer (grype) revealed that one input shape doesn't fit all:
+//   - Package-query sources (OSV) match Packages against a vuln database.
+//   - Document sources (grype) consume SBOMPath directly, because the full SBOM
+//     document carries the OS/distro metadata that distro-advisory (ALAS) matching
+//     needs — metadata the minimal Packages list drops.
 //
-// pkgs is the identified package set for the artifact (from an SBOM, or — for an
-// AMI source — enumerated off the image). The Source decides how to match them to
-// advisories; that matching is the whole point of the seam.
+// A Source documents which fields it requires and errors clearly when they're
+// absent (fail-closed), rather than silently scanning nothing.
+type Target struct {
+	// Packages are the parsed package identities from the artifact's SBOM.
+	Packages []sbom.Package
+	// SBOMPath is the path to the full SBOM document on disk, "" when none exists.
+	SBOMPath string
+}
+
+// Source evaluates a Target for known vulnerabilities. A Source must fail closed:
+// if it cannot evaluate the target (database unreachable, a required input
+// missing, the scanner tool absent), it returns a non-nil error rather than a
+// falsely-clean Verdict. Returning a clean Verdict means "evaluated, and nothing
+// critical/high was found." How the matching is done — per-package query, or a
+// distro-aware document scan — is the whole point of the seam.
 type Source interface {
-	// Name identifies the source for logs and records, e.g. "osv".
+	// Name identifies the source for logs and records, e.g. "osv" / "grype".
 	Name() string
-	// Scan evaluates pkgs and returns the critical/high verdict.
-	Scan(ctx context.Context, pkgs []sbom.Package) (Verdict, error)
+	// Scan evaluates the target and returns the critical/high verdict.
+	Scan(ctx context.Context, target Target) (Verdict, error)
 }

--- a/internal/cve/grype.go
+++ b/internal/cve/grype.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package cve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Runner executes external commands (mockable in tests). Mirrors the seam in
+// internal/sbom and internal/verify so grype can be driven by a fake.
+type Runner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type defaultRunner struct{}
+
+func (defaultRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...) // #nosec G204 — controlled inputs
+	return cmd.CombinedOutput()
+}
+
+// GrypeSource scans an SBOM document with grype (anchore/grype). Unlike the OSV
+// source, grype is **distro-advisory aware**: it consumes the full SBOM document
+// (which carries the OS/distro metadata) and matches Amazon Linux / RHEL / Debian
+// packages against their distro security feeds (e.g. Amazon ALAS) — not just the
+// upstream-kernel-scoped OSV "Linux" ecosystem. This is the source that fixes the
+// false-clean gap a naive OSV scan has on a distro AMI (provabl/vet#32).
+//
+// It requires Target.SBOMPath (the document on disk); Target.Packages is ignored,
+// because the lossy package list drops exactly the distro metadata grype needs.
+type GrypeSource struct {
+	runner Runner
+}
+
+// NewGrypeSource returns a GrypeSource using the real command runner.
+func NewGrypeSource() *GrypeSource { return &GrypeSource{runner: defaultRunner{}} }
+
+// NewGrypeSourceWithRunner returns a GrypeSource with a custom runner (tests).
+func NewGrypeSourceWithRunner(r Runner) *GrypeSource { return &GrypeSource{runner: r} }
+
+// Name identifies the source.
+func (*GrypeSource) Name() string { return "grype" }
+
+// Scan runs grype over the target's SBOM document and returns the critical/high
+// verdict. Fail-closed: a missing SBOM path, an absent grype binary, a non-zero
+// grype exit, or unparseable output all return an error (the gate then denies)
+// rather than a falsely-clean verdict.
+func (s *GrypeSource) Scan(ctx context.Context, target Target) (Verdict, error) {
+	if target.SBOMPath == "" {
+		return Verdict{}, fmt.Errorf("grype source requires an SBOM document path (none provided)")
+	}
+	if err := requireGrype(ctx, s.runner); err != nil {
+		return Verdict{}, err
+	}
+	// grype reads the SBOM document so the distro metadata drives ALAS-aware
+	// matching. `sbom:<path>` is grype's explicit SBOM-input scheme.
+	out, err := s.runner.Run(ctx, "grype", "sbom:"+target.SBOMPath, "-o", "json")
+	if err != nil {
+		return Verdict{}, fmt.Errorf("grype: %w\nOutput: %s", err, sanitize(string(out)))
+	}
+	return parseGrype(out)
+}
+
+// requireGrype reports a clear error when the grype binary is not invokable, so a
+// requested distro scan that cannot run fails closed rather than silently.
+func requireGrype(ctx context.Context, r Runner) error {
+	if _, err := r.Run(ctx, "grype", "version"); err != nil {
+		return fmt.Errorf("grype not found — install from https://github.com/anchore/grype#installation")
+	}
+	return nil
+}
+
+// grypeReport is the subset of grype's JSON output we read: each match carries a
+// vulnerability with a severity string ("Critical", "High", "Medium", …).
+type grypeReport struct {
+	Matches []struct {
+		Vulnerability struct {
+			Severity string `json:"severity"`
+		} `json:"vulnerability"`
+	} `json:"matches"`
+}
+
+// parseGrype turns grype's JSON into a Verdict. Scanned counts the matches
+// examined (grype reports one match per vulnerable package/vuln pair).
+func parseGrype(out []byte) (Verdict, error) {
+	var r grypeReport
+	if err := json.Unmarshal(out, &r); err != nil {
+		return Verdict{}, fmt.Errorf("parse grype output: %w", err)
+	}
+	v := Verdict{Scanned: len(r.Matches)}
+	for _, m := range r.Matches {
+		switch strings.ToUpper(m.Vulnerability.Severity) {
+		case "CRITICAL":
+			v.Critical = true
+		case "HIGH":
+			v.High = true
+		}
+	}
+	return v, nil
+}
+
+// sanitize strips control characters from tool output before it goes into an
+// error message.
+func sanitize(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r >= 0x20 || r == '\n' || r == '\t' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/internal/cve/grype_test.go
+++ b/internal/cve/grype_test.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package cve
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeRunner serves canned output/errors keyed by the first argument, so grype's
+// `version` probe and the scan invocation can be answered independently.
+type fakeRunner struct {
+	versionErr error    // returned for `grype version`
+	scanOut    string   // returned for `grype sbom:...`
+	scanErr    error    // returned for `grype sbom:...`
+	gotArgs    []string // records the scan args for assertions
+}
+
+func (f *fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	if len(args) > 0 && args[0] == "version" {
+		return []byte("grype 0.x"), f.versionErr
+	}
+	f.gotArgs = append([]string{name}, args...)
+	return []byte(f.scanOut), f.scanErr
+}
+
+const grypeCritical = `{"matches":[{"vulnerability":{"severity":"Critical"}},{"vulnerability":{"severity":"Medium"}}]}`
+const grypeHigh = `{"matches":[{"vulnerability":{"severity":"High"}}]}`
+const grypeClean = `{"matches":[]}`
+
+func TestGrype_Name(t *testing.T) {
+	if NewGrypeSource().Name() != "grype" {
+		t.Error("Name() should be grype")
+	}
+}
+
+func TestGrype_CriticalFlagged(t *testing.T) {
+	r := &fakeRunner{scanOut: grypeCritical}
+	v, err := NewGrypeSourceWithRunner(r).Scan(context.Background(), Target{SBOMPath: "/tmp/sbom.json"})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if !v.Critical || v.Scanned != 2 {
+		t.Errorf("expected Critical with Scanned=2, got %+v", v)
+	}
+	// grype must be driven over the SBOM document (so distro metadata is present).
+	joined := strings.Join(r.gotArgs, " ")
+	if !strings.Contains(joined, "sbom:/tmp/sbom.json") {
+		t.Errorf("expected grype to scan the SBOM document, got args: %v", r.gotArgs)
+	}
+}
+
+func TestGrype_HighFlagged(t *testing.T) {
+	v, err := NewGrypeSourceWithRunner(&fakeRunner{scanOut: grypeHigh}).
+		Scan(context.Background(), Target{SBOMPath: "/tmp/s.json"})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if v.Critical || !v.High {
+		t.Errorf("expected High only, got %+v", v)
+	}
+}
+
+func TestGrype_CleanPasses(t *testing.T) {
+	v, err := NewGrypeSourceWithRunner(&fakeRunner{scanOut: grypeClean}).
+		Scan(context.Background(), Target{SBOMPath: "/tmp/s.json"})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if v.Critical || v.High || v.Scanned != 0 {
+		t.Errorf("expected clean empty verdict, got %+v", v)
+	}
+}
+
+// No SBOM path → fail closed (grype needs the document for distro matching).
+func TestGrype_NoSBOMPathFailsClosed(t *testing.T) {
+	_, err := NewGrypeSourceWithRunner(&fakeRunner{scanOut: grypeClean}).
+		Scan(context.Background(), Target{})
+	if err == nil {
+		t.Fatal("expected error when no SBOM path is provided")
+	}
+}
+
+// grype binary absent → fail closed with an install hint.
+func TestGrype_MissingBinaryFailsClosed(t *testing.T) {
+	r := &fakeRunner{versionErr: errors.New("exec: grype not found")}
+	_, err := NewGrypeSourceWithRunner(r).Scan(context.Background(), Target{SBOMPath: "/tmp/s.json"})
+	if err == nil || !strings.Contains(err.Error(), "grype not found") {
+		t.Fatalf("expected missing-binary fail-closed, got %v", err)
+	}
+}
+
+// grype exits non-zero → fail closed.
+func TestGrype_ScanErrorFailsClosed(t *testing.T) {
+	r := &fakeRunner{scanErr: errors.New("exit status 1"), scanOut: "boom"}
+	_, err := NewGrypeSourceWithRunner(r).Scan(context.Background(), Target{SBOMPath: "/tmp/s.json"})
+	if err == nil {
+		t.Fatal("expected fail-closed on grype non-zero exit")
+	}
+}
+
+// Unparseable grype output → fail closed (never a silent clean pass).
+func TestGrype_BadJSONFailsClosed(t *testing.T) {
+	r := &fakeRunner{scanOut: "not json"}
+	_, err := NewGrypeSourceWithRunner(r).Scan(context.Background(), Target{SBOMPath: "/tmp/s.json"})
+	if err == nil {
+		t.Fatal("expected fail-closed on unparseable grype output")
+	}
+}

--- a/internal/cve/osv.go
+++ b/internal/cve/osv.go
@@ -47,12 +47,13 @@ func NewOSVSource(client *http.Client) *OSVSource {
 // Name identifies the source.
 func (*OSVSource) Name() string { return "osv" }
 
-// Scan queries OSV for each package and returns the aggregate critical/high
-// verdict. Fail-closed: a transport error mid-scan returns an error (the caller
-// must not pass), rather than under-reporting. A package OSV cannot resolve (no
-// PURL, no ecosystem) is skipped — a bare name is ambiguous across ecosystems —
-// but counted as not-scanned so the caller can see coverage.
-func (s *OSVSource) Scan(ctx context.Context, pkgs []sbom.Package) (Verdict, error) {
+// Scan queries OSV for each package in the target and returns the aggregate
+// critical/high verdict. Fail-closed: a transport error mid-scan returns an error
+// (the caller must not pass), rather than under-reporting. A package OSV cannot
+// resolve (no PURL, no ecosystem) is skipped — a bare name is ambiguous across
+// ecosystems — but counted as not-scanned so the caller can see coverage.
+func (s *OSVSource) Scan(ctx context.Context, target Target) (Verdict, error) {
+	pkgs := target.Packages
 	if len(pkgs) > maxOSVPackages {
 		pkgs = pkgs[:maxOSVPackages]
 	}

--- a/internal/cve/osv_test.go
+++ b/internal/cve/osv_test.go
@@ -34,6 +34,11 @@ func osvSourceWith(tr *stubTransport) *OSVSource {
 	return NewOSVSource(&http.Client{Transport: tr})
 }
 
+// scanPkgs scans a package list as a Target (OSV uses Target.Packages).
+func scanPkgs(s *OSVSource, pkgs ...sbom.Package) (Verdict, error) {
+	return s.Scan(context.Background(), Target{Packages: pkgs})
+}
+
 const (
 	osvCritical = `{"vulns":[{"id":"GHSA-x","database_specific":{"severity":"CRITICAL"}}]}`
 	osvHigh     = `{"vulns":[{"id":"GHSA-y","database_specific":{"severity":"HIGH"}}]}`
@@ -48,7 +53,7 @@ func TestOSV_Name(t *testing.T) {
 
 func TestOSV_CriticalFlagged(t *testing.T) {
 	tr := &stubTransport{respFor: func(string) (int, string) { return 200, osvCritical }}
-	v, err := osvSourceWith(tr).Scan(context.Background(), []sbom.Package{{PURL: "pkg:npm/left-pad@1.0.0"}})
+	v, err := scanPkgs(osvSourceWith(tr), sbom.Package{PURL: "pkg:npm/left-pad@1.0.0"})
 	if err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
@@ -62,7 +67,7 @@ func TestOSV_CriticalFlagged(t *testing.T) {
 
 func TestOSV_HighFlagged(t *testing.T) {
 	tr := &stubTransport{respFor: func(string) (int, string) { return 200, osvHigh }}
-	v, _ := osvSourceWith(tr).Scan(context.Background(), []sbom.Package{{PURL: "pkg:npm/x@1.0.0"}})
+	v, _ := scanPkgs(osvSourceWith(tr), sbom.Package{PURL: "pkg:npm/x@1.0.0"})
 	if v.Critical || !v.High {
 		t.Errorf("expected High only, got %+v", v)
 	}
@@ -70,7 +75,7 @@ func TestOSV_HighFlagged(t *testing.T) {
 
 func TestOSV_CleanPasses(t *testing.T) {
 	tr := &stubTransport{respFor: func(string) (int, string) { return 200, osvClean }}
-	v, err := osvSourceWith(tr).Scan(context.Background(), []sbom.Package{{PURL: "pkg:npm/safe@1.0.0"}})
+	v, err := scanPkgs(osvSourceWith(tr), sbom.Package{PURL: "pkg:npm/safe@1.0.0"})
 	if err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
@@ -85,7 +90,7 @@ func TestOSV_CleanPasses(t *testing.T) {
 // A transport error mid-scan must fail closed (error, not a clean verdict).
 func TestOSV_TransportErrorFailsClosed(t *testing.T) {
 	tr := &stubTransport{respFor: func(string) (int, string) { return 503, "" }}
-	_, err := osvSourceWith(tr).Scan(context.Background(), []sbom.Package{{PURL: "pkg:npm/x@1.0.0"}})
+	_, err := scanPkgs(osvSourceWith(tr), sbom.Package{PURL: "pkg:npm/x@1.0.0"})
 	if err == nil {
 		t.Fatal("expected fail-closed error on OSV 503")
 	}
@@ -96,7 +101,7 @@ func TestOSV_TransportErrorFailsClosed(t *testing.T) {
 // OSV source honestly reports it scanned nothing rather than falsely passing it.
 func TestOSV_UnresolvablePackageSkipped(t *testing.T) {
 	tr := &stubTransport{respFor: func(string) (int, string) { return 200, osvClean }}
-	v, err := osvSourceWith(tr).Scan(context.Background(), []sbom.Package{{Name: "bash", Version: "5.2.15"}})
+	v, err := scanPkgs(osvSourceWith(tr), sbom.Package{Name: "bash", Version: "5.2.15"})
 	if err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
@@ -110,7 +115,7 @@ func TestOSV_UnresolvablePackageSkipped(t *testing.T) {
 
 func TestOSV_ByEcosystem(t *testing.T) {
 	tr := &stubTransport{respFor: func(string) (int, string) { return 200, osvCritical }}
-	v, _ := osvSourceWith(tr).Scan(context.Background(), []sbom.Package{{Name: "django", Version: "3.0", Ecosystem: "PyPI"}})
+	v, _ := scanPkgs(osvSourceWith(tr), sbom.Package{Name: "django", Version: "3.0", Ecosystem: "PyPI"})
 	if !v.Critical || v.Scanned != 1 {
 		t.Errorf("ecosystem-keyed package should scan + flag, got %+v", v)
 	}
@@ -124,10 +129,10 @@ func TestOSV_AggregatesAcrossPackages(t *testing.T) {
 		}
 		return 200, osvClean
 	}}
-	v, err := osvSourceWith(tr).Scan(context.Background(), []sbom.Package{
-		{PURL: "pkg:npm/safe@1.0.0"},
-		{PURL: "pkg:npm/bad@1.0.0"},
-	})
+	v, err := scanPkgs(osvSourceWith(tr),
+		sbom.Package{PURL: "pkg:npm/safe@1.0.0"},
+		sbom.Package{PURL: "pkg:npm/bad@1.0.0"},
+	)
 	if err != nil {
 		t.Fatalf("Scan: %v", err)
 	}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -92,6 +92,7 @@ type VerifyResult struct {
 	SBOMPresent     bool
 	CVECritical     bool
 	CVEHigh         bool
+	CVECheckRan     bool // the CVE source actually evaluated (vs. failed to run / not requested)
 	PolicyMet       bool
 	Failures        []string // human-readable failure list
 }
@@ -147,6 +148,7 @@ func (v *Verifier) Verify(ctx context.Context, artifactRef string, opts Options)
 	var cveErr error
 	if opts.CheckCVEs != "" {
 		critical, high, ran, err := v.checkCVEs(ctx, artifactRef)
+		result.CVECheckRan = ran
 		if ran {
 			result.CVECritical = critical
 			result.CVEHigh = high
@@ -305,12 +307,22 @@ func toolAvailable(ctx context.Context, r Runner, name string) bool {
 // sbomPackages loads the parsed package list for an artifact, trying SPDX then
 // CycloneDX. Returns nil when no parseable, non-empty SBOM exists.
 func (v *Verifier) sbomPackages(artifactRef string) []sbom.Package {
+	pkgs, _ := v.sbomTarget(artifactRef)
+	return pkgs
+}
+
+// sbomTarget loads both the parsed package list AND the on-disk SBOM path for an
+// artifact, trying SPDX then CycloneDX. The path lets a document source (grype)
+// consume the full SBOM (with distro metadata), while package-query sources (OSV)
+// use the parsed list. Returns (nil, "") when no parseable, non-empty SBOM exists.
+func (v *Verifier) sbomTarget(artifactRef string) ([]sbom.Package, string) {
 	for _, format := range []string{"spdx", "cyclonedx"} {
-		if pkgs, err := sbom.Load(v.store.SBOMPath(artifactRef, format)); err == nil && len(pkgs) > 0 {
-			return pkgs
+		path := v.store.SBOMPath(artifactRef, format)
+		if pkgs, err := sbom.Load(path); err == nil && len(pkgs) > 0 {
+			return pkgs, path
 		}
 	}
-	return nil
+	return nil, ""
 }
 
 // checkCVEs loads the artifact's SBOM and delegates to the configured CVE source.
@@ -319,13 +331,13 @@ func (v *Verifier) sbomPackages(artifactRef string) []sbom.Package {
 // not pass). The scanning strategy itself lives in internal/cve — OSV by default,
 // a distro-aware source for AMIs (provabl/vet#32).
 func (v *Verifier) checkCVEs(ctx context.Context, artifactRef string) (critical, high, ran bool, err error) {
-	pkgs := v.sbomPackages(artifactRef)
+	pkgs, sbomPath := v.sbomTarget(artifactRef)
 	if pkgs == nil {
 		return false, false, false, fmt.Errorf("no SBOM present — run 'vet sbom %s' first", artifactRef)
 	}
-	verdict, scanErr := v.cveSource.Scan(ctx, pkgs)
+	verdict, scanErr := v.cveSource.Scan(ctx, cve.Target{Packages: pkgs, SBOMPath: sbomPath})
 	if scanErr != nil {
-		// Source could not evaluate (DB unreachable, …): fail closed.
+		// Source could not evaluate (DB unreachable, tool missing, …): fail closed.
 		return false, false, false, scanErr
 	}
 	return verdict.Critical, verdict.High, true, nil


### PR DESCRIPTION
Second slice of **vet#32**. Adds the distro-aware CVE source that fixes the false-clean gap the live both-source test found, and routes AMI targets to it. Still no AWS — fully fake-tested.

## Why

The [live test](https://github.com/provabl/vet/issues/32#issuecomment-4803827591) showed a naive OSV `Linux` query reports a distro AMI (Amazon Linux) as **clean** even when it isn't — OSV's `Linux` ecosystem is upstream-kernel-scoped, not ALAS-aware. grype *is* distro-advisory aware (it matches AL/RHEL/Debian packages against their feeds, incl. Amazon ALAS), so it's the right matcher for an AMI.

## What

- **`cve.GrypeSource`** — shells to `grype sbom:<path> -o json` over the **SBOM document** and parses severities. Fail-closed: missing SBOM path, absent `grype` binary, non-zero exit, or unparseable output all deny.
- **`cve.Source` now takes `Target{Packages, SBOMPath}`** — the second implementer revealed one input shape doesn't fit both: OSV queries `Packages`; grype needs the full document (the lossy package list drops the distro metadata grype relies on). `OSVSource` reads `Target.Packages`; behaviour unchanged.
- **`vet verify --cve-source auto|osv|grype`** (default `auto`): an `ami-…` target routes to grype, everything else to OSV; explicit value overrides. `resolveCVESource` unit-tested.
- **`VerifyResult.CVECheckRan`** — the CLI no longer prints "✓ No critical/high CVEs found" when the check actually failed to run (e.g. grype absent); it shows only the fail-closed violation. (Caught in a CLI smoke test.)

## Tests

- `internal/cve/grype_test.go`: critical / high / clean / no-SBOM-path / missing-binary / scan-error / bad-JSON — all fail-closed paths covered.
- `cmd/vet/cve_source_test.go`: the auto/explicit/unknown routing matrix.
- Existing OSV + verify tests updated to the `Target` signature, green.
- Smoke-tested the CLI: AMI verify auto-selects grype and fails closed with an install hint when grype is absent.

## Next slice

The live AWS wiring — `vet verify ami-…` snapshots the AMI's EBS volume, syfts the mounted filesystem to produce the SBOM, then this grype source scans it. That slice creates real resources, so it'll follow the suite's injectable-interface + manual-live-wiring pattern.

> Note: `gofmt` flags `internal/sign/sign.go` on the current toolchain — pre-existing drift, untouched here.