### PR TITLE
feat: AMI content-scan orchestration (internal/amiscan) — vet#32 slice 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
+- **`internal/amiscan` — AMI content-scan orchestration** (provabl/vet#32, slice 3): an AMI's contents
+  aren't directly scannable — you reach them through snapshot → volume → attach → mount → syft. This
+  slice ships the **orchestration core** (resolve the AMI's backing EBS snapshot, drive the steps, and
+  **guarantee teardown even on failure**) behind two seams: `ImageInspector` (read-only EC2
+  `DescribeImages`, resolves the backing snapshot — root-device-preferred, first-EBS fallback) and
+  `Mounter` (the live-only snapshot→filesystem→SBOM step). `Scan` returns an **SBOM path** (not a
+  verdict) for the grype `cve.Source` to scan — keeping CVE matching in `internal/cve` and AWS plumbing
+  here. Fully fake-tested incl. the leak-safety cases (a mount that yields no SBOM is still released;
+  no mount → no release returned); the EC2 inspector's resolution validated read-only against a real
+  AL2023 AMI. The live `Mounter` impl (EBS attach + mount + syft, with full resource teardown) is the
+  next slice — it creates real resources, so it lands with live validation, not in CI.
+
 - **`cve.GrypeSource` — distro-aware CVE scanning for AMIs** (provabl/vet#32, slice 2): a second
   `cve.Source` that scans the **SBOM document** with grype (anchore/grype), which is distro-advisory
   aware (matches Amazon Linux / RHEL / Debian packages against their security feeds, e.g. Amazon ALAS)

--- a/internal/amiscan/amiscan.go
+++ b/internal/amiscan/amiscan.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package amiscan orchestrates deep-content scanning of an AWS AMI: it resolves
+// the AMI's backing EBS snapshot, materialises that snapshot's filesystem, runs
+// syft over it to produce an SBOM, and returns the SBOM path for a distro-aware
+// CVE source (grype) to scan. It is the live-AWS half of provabl/vet#32.
+//
+// An AMI's contents are not directly scannable — you reach them through
+// snapshot → volume → attach → mount. That lifecycle is bug-prone (every created
+// resource must be torn down, even on failure) and inherently live-only (the
+// mount cannot be meaningfully faked). So this package splits the problem:
+//
+//   - The ORCHESTRATION (resolve the snapshot, drive the steps, GUARANTEE
+//     teardown) lives here and is fully fake-testable — it is where the bugs are.
+//   - The two effectful steps are interfaces: ImageInspector (read-only EC2,
+//     resolves the backing snapshot) and Mounter (the live snapshot→filesystem→
+//     SBOM step). Production impls wire AWS; tests use fakes.
+//
+// Nothing here computes a verdict — Scan returns an SBOM path; the caller feeds it
+// to a cve.Source (grype) exactly as for any other SBOM. This keeps the CVE
+// strategy in one place (internal/cve) and the AWS plumbing in another.
+package amiscan
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// ImageInspector resolves AMI metadata. Satisfied by the EC2 client in
+// production (ec2:DescribeImages, read-only); faked in tests.
+type ImageInspector interface {
+	// BackingSnapshot returns the EBS snapshot id backing the AMI's root device.
+	BackingSnapshot(ctx context.Context, amiID string) (string, error)
+}
+
+// Mount is a materialised, readable copy of a snapshot's filesystem plus the SBOM
+// produced from it. Release tears down everything the Mounter created for it.
+type Mount struct {
+	// SBOMPath is the path to the SBOM document syft produced from the filesystem.
+	SBOMPath string
+	// Release tears down whatever the Mounter created (temp volume, attachment,
+	// helper resources). It must be safe to call exactly once; the orchestrator
+	// always calls it.
+	Release func(context.Context) error
+}
+
+// Mounter materialises a snapshot's filesystem and produces an SBOM from it. This
+// is the live-only step (snapshot → volume → attach → mount → syft); production
+// wires AWS + syft, tests fake it. A Mounter must not leak resources: everything
+// it creates is released via Mount.Release.
+type Mounter interface {
+	Mount(ctx context.Context, snapshotID string) (*Mount, error)
+}
+
+// Scanner orchestrates an AMI content scan end to end.
+type Scanner struct {
+	inspector ImageInspector
+	mounter   Mounter
+}
+
+// New builds a Scanner from an inspector and a mounter.
+func New(inspector ImageInspector, mounter Mounter) *Scanner {
+	return &Scanner{inspector: inspector, mounter: mounter}
+}
+
+// Scan resolves the AMI's backing snapshot, mounts it, and returns the path to
+// the SBOM syft produced — for a cve.Source to scan. The returned release tears
+// down everything created for the scan; the caller MUST call it (typically
+// deferred) once it has finished with the SBOM. On any failure before a mount is
+// established, Scan tears down what it created and returns a nil release.
+//
+// Returning the SBOM path (not a verdict) keeps the CVE matching in internal/cve:
+// the caller does `src.Scan(ctx, cve.Target{SBOMPath: path})` with a grype source.
+func (s *Scanner) Scan(ctx context.Context, amiID string) (sbomPath string, release func(context.Context) error, err error) {
+	if !strings.HasPrefix(amiID, "ami-") {
+		return "", nil, fmt.Errorf("expected an AMI id (ami-...), got %q", amiID)
+	}
+	snap, err := s.inspector.BackingSnapshot(ctx, amiID)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve backing snapshot for %s: %w", amiID, err)
+	}
+	if snap == "" {
+		return "", nil, fmt.Errorf("AMI %s has no backing EBS snapshot to scan", amiID)
+	}
+	mount, err := s.mounter.Mount(ctx, snap)
+	if err != nil {
+		return "", nil, fmt.Errorf("mount snapshot %s: %w", snap, err)
+	}
+	if mount == nil || mount.SBOMPath == "" {
+		// Defensive: a Mounter that returns no SBOM but also no error. Tear down
+		// whatever it may have created, and fail closed.
+		if mount != nil && mount.Release != nil {
+			_ = mount.Release(ctx)
+		}
+		return "", nil, fmt.Errorf("mounter produced no SBOM for snapshot %s", snap)
+	}
+	return mount.SBOMPath, mount.Release, nil
+}

--- a/internal/amiscan/amiscan_test.go
+++ b/internal/amiscan/amiscan_test.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package amiscan
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakeInspector struct {
+	snap string
+	err  error
+}
+
+func (f fakeInspector) BackingSnapshot(context.Context, string) (string, error) {
+	return f.snap, f.err
+}
+
+type fakeMounter struct {
+	mount    *Mount
+	err      error
+	mounted  string // snapshot id it was asked to mount
+	released bool
+}
+
+func (f *fakeMounter) Mount(_ context.Context, snap string) (*Mount, error) {
+	f.mounted = snap
+	if f.err != nil {
+		return nil, f.err
+	}
+	m := f.mount
+	if m != nil && m.Release == nil {
+		m.Release = func(context.Context) error { f.released = true; return nil }
+	}
+	return m, nil
+}
+
+func okMount(path string) *Mount { return &Mount{SBOMPath: path} }
+
+func TestScan_HappyPath(t *testing.T) {
+	m := &fakeMounter{mount: okMount("/tmp/ami.sbom.json")}
+	s := New(fakeInspector{snap: "snap-123"}, m)
+
+	path, release, err := s.Scan(context.Background(), "ami-0abc")
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if path != "/tmp/ami.sbom.json" {
+		t.Errorf("sbom path = %q", path)
+	}
+	if m.mounted != "snap-123" {
+		t.Errorf("mounted %q, want snap-123 (the resolved backing snapshot)", m.mounted)
+	}
+	if release == nil {
+		t.Fatal("expected a non-nil release to tear down the mount")
+	}
+	if err := release(context.Background()); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if !m.released {
+		t.Error("release did not tear the mount down")
+	}
+}
+
+func TestScan_RejectsNonAMIRef(t *testing.T) {
+	s := New(fakeInspector{snap: "snap-1"}, &fakeMounter{mount: okMount("/x")})
+	if _, _, err := s.Scan(context.Background(), "ghcr.io/o/i:v1"); err == nil {
+		t.Error("expected an error for a non-AMI ref")
+	}
+}
+
+func TestScan_InspectorError(t *testing.T) {
+	m := &fakeMounter{mount: okMount("/x")}
+	s := New(fakeInspector{err: errors.New("describe boom")}, m)
+	if _, _, err := s.Scan(context.Background(), "ami-0abc"); err == nil {
+		t.Error("expected inspector error to propagate")
+	}
+	if m.mounted != "" {
+		t.Error("must not attempt a mount when the snapshot cannot be resolved")
+	}
+}
+
+func TestScan_NoBackingSnapshot(t *testing.T) {
+	m := &fakeMounter{mount: okMount("/x")}
+	s := New(fakeInspector{snap: ""}, m)
+	if _, _, err := s.Scan(context.Background(), "ami-0abc"); err == nil {
+		t.Error("expected an error when the AMI has no backing snapshot")
+	}
+	if m.mounted != "" {
+		t.Error("must not mount when there is no snapshot")
+	}
+}
+
+func TestScan_MountError(t *testing.T) {
+	s := New(fakeInspector{snap: "snap-1"}, &fakeMounter{err: errors.New("attach failed")})
+	_, release, err := s.Scan(context.Background(), "ami-0abc")
+	if err == nil {
+		t.Error("expected mount error to propagate")
+	}
+	if release != nil {
+		t.Error("no release should be returned when no mount was established")
+	}
+}
+
+// A Mounter that returns a mount with no SBOM (but no error) must fail closed AND
+// still release whatever it created — the orchestrator must never leak.
+func TestScan_MountWithoutSBOMReleasesAndFails(t *testing.T) {
+	released := false
+	bad := &Mount{SBOMPath: "", Release: func(context.Context) error { released = true; return nil }}
+	s := New(fakeInspector{snap: "snap-1"}, &fakeMounter{mount: bad})
+
+	_, release, err := s.Scan(context.Background(), "ami-0abc")
+	if err == nil {
+		t.Error("expected fail-closed when the mounter produced no SBOM")
+	}
+	if release != nil {
+		t.Error("no usable release should be returned on failure")
+	}
+	if !released {
+		t.Error("the partial mount must be torn down even though it had no SBOM")
+	}
+}

--- a/internal/amiscan/ec2_inspector.go
+++ b/internal/amiscan/ec2_inspector.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package amiscan
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+// describeImagesAPI is the read-only EC2 call the inspector needs (mockable).
+type describeImagesAPI interface {
+	DescribeImages(ctx context.Context, in *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error)
+}
+
+// ec2Inspector resolves an AMI's backing snapshot via ec2:DescribeImages.
+type ec2Inspector struct{ client describeImagesAPI }
+
+// NewEC2Inspector builds an ImageInspector backed by the AWS EC2 client.
+func NewEC2Inspector(ctx context.Context, region string) (ImageInspector, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("load AWS config: %w", err)
+	}
+	return &ec2Inspector{client: ec2.NewFromConfig(cfg)}, nil
+}
+
+// BackingSnapshot returns the EBS snapshot backing the AMI's root device. It picks
+// the mapping matching the image's RootDeviceName, falling back to the first
+// EBS mapping — an AMI's root volume is the one whose filesystem we scan.
+func (i *ec2Inspector) BackingSnapshot(ctx context.Context, amiID string) (string, error) {
+	out, err := i.client.DescribeImages(ctx, &ec2.DescribeImagesInput{ImageIds: []string{amiID}})
+	if err != nil {
+		return "", err
+	}
+	if len(out.Images) == 0 {
+		return "", fmt.Errorf("AMI %s not found", amiID)
+	}
+	img := out.Images[0]
+	root := aws.ToString(img.RootDeviceName)
+	var firstEBS string
+	for _, m := range img.BlockDeviceMappings {
+		if m.Ebs == nil || m.Ebs.SnapshotId == nil {
+			continue
+		}
+		snap := aws.ToString(m.Ebs.SnapshotId)
+		if firstEBS == "" {
+			firstEBS = snap
+		}
+		if aws.ToString(m.DeviceName) == root {
+			return snap, nil
+		}
+	}
+	return firstEBS, nil
+}

--- a/internal/amiscan/ec2_inspector_test.go
+++ b/internal/amiscan/ec2_inspector_test.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package amiscan
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+type fakeDescribe struct {
+	out *ec2.DescribeImagesOutput
+	err error
+}
+
+func (f fakeDescribe) DescribeImages(context.Context, *ec2.DescribeImagesInput, ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error) {
+	return f.out, f.err
+}
+
+func img(root string, mappings ...ec2types.BlockDeviceMapping) *ec2.DescribeImagesOutput {
+	return &ec2.DescribeImagesOutput{Images: []ec2types.Image{{
+		RootDeviceName:      aws.String(root),
+		BlockDeviceMappings: mappings,
+	}}}
+}
+
+func ebs(dev, snap string) ec2types.BlockDeviceMapping {
+	return ec2types.BlockDeviceMapping{
+		DeviceName: aws.String(dev),
+		Ebs:        &ec2types.EbsBlockDevice{SnapshotId: aws.String(snap)},
+	}
+}
+
+func TestBackingSnapshot_PrefersRootDevice(t *testing.T) {
+	i := &ec2Inspector{client: fakeDescribe{out: img("/dev/xvda",
+		ebs("/dev/sdb", "snap-data"),
+		ebs("/dev/xvda", "snap-root"),
+	)}}
+	got, err := i.BackingSnapshot(context.Background(), "ami-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "snap-root" {
+		t.Errorf("got %q, want snap-root (the root device's snapshot)", got)
+	}
+}
+
+func TestBackingSnapshot_FallsBackToFirstEBS(t *testing.T) {
+	// Root device name doesn't match any mapping → fall back to the first EBS.
+	i := &ec2Inspector{client: fakeDescribe{out: img("/dev/xvda",
+		ebs("/dev/sdb", "snap-only"),
+	)}}
+	got, _ := i.BackingSnapshot(context.Background(), "ami-1")
+	if got != "snap-only" {
+		t.Errorf("got %q, want snap-only", got)
+	}
+}
+
+func TestBackingSnapshot_NotFound(t *testing.T) {
+	i := &ec2Inspector{client: fakeDescribe{out: &ec2.DescribeImagesOutput{}}}
+	if _, err := i.BackingSnapshot(context.Background(), "ami-missing"); err == nil {
+		t.Error("expected an error when the AMI is not found")
+	}
+}
+
+func TestBackingSnapshot_APIError(t *testing.T) {
+	i := &ec2Inspector{client: fakeDescribe{err: errors.New("AccessDenied")}}
+	if _, err := i.BackingSnapshot(context.Background(), "ami-1"); err == nil {
+		t.Error("expected the DescribeImages error to propagate")
+	}
+}
+
+func TestBackingSnapshot_NoEBSMapping(t *testing.T) {
+	// An instance-store AMI with no EBS mapping → empty (caller fails closed).
+	i := &ec2Inspector{client: fakeDescribe{out: img("/dev/sda1")}}
+	got, _ := i.BackingSnapshot(context.Background(), "ami-1")
+	if got != "" {
+		t.Errorf("got %q, want empty (no EBS snapshot to scan)", got)
+	}
+}


### PR DESCRIPTION
Third slice of **vet#32**. Ships the testable half of the live AMI content-scan: the orchestration that resolves an AMI's backing snapshot, drives the scan, and guarantees teardown. No resources created in CI.

## Why this shape

An AMI's contents aren't directly scannable — you reach them through **snapshot → volume → attach → mount → syft**. That lifecycle is (a) bug-prone — every created resource must be torn down, even on failure — and (b) inherently live-only — the mount can't be meaningfully faked. So the slice splits the problem:

- **Orchestration** (resolve snapshot, drive steps, *guarantee teardown*) → `internal/amiscan`, fully fake-tested. This is where the bugs are.
- **Two seams**: `ImageInspector` (read-only EC2 `DescribeImages`) and `Mounter` (the live step). The inspector's production impl ships here; the live `Mounter` is the next slice.

## What

- **`amiscan.Scanner.Scan`** resolves the AMI's backing EBS snapshot, mounts it, and returns the **SBOM path** (not a verdict) — the caller feeds it to a grype `cve.Source`, keeping CVE matching in `internal/cve` and AWS plumbing in `amiscan`.
- **`ImageInspector`** (EC2 `DescribeImages`, read-only): root-device-preferred snapshot resolution, first-EBS fallback. Resolution logic validated **read-only against a real AL2023 AMI** (`/dev/xvda` → `snap-0ddddd…`); no resources created.
- **Guaranteed teardown**: a mount that yields no SBOM is still released (no leak); on any pre-mount failure, no release is returned. Both unit-tested.

## Tests

- `amiscan_test.go`: happy path, non-AMI ref, inspector error, no-backing-snapshot, mount error, **no-SBOM-releases-and-fails** (leak safety).
- `ec2_inspector_test.go`: root-preference, first-EBS fallback, not-found, API error, instance-store (no EBS).

## Next slice

The live `Mounter` impl: create a volume from the snapshot, attach it to a helper instance, mount, syft the filesystem, **then tear it all down**. It creates real resources, so it lands with live validation + verified teardown (the discipline used for the Inspector test), not in CI.

> Note: `gofmt` flags `internal/sign/sign.go` on the current toolchain — pre-existing drift, untouched here.