### PR TITLE
feat: live AMI Mounter — volume lifecycle with guaranteed teardown — vet#32 slice 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
+- **`amiscan` live Mounter — volume lifecycle with guaranteed teardown** (provabl/vet#32, slice 4):
+  the `Mounter` impl that turns a backing snapshot into a scannable filesystem — `CreateVolume(from
+  snapshot) → Attach(to helper) → remote mount + syft → [Release] Detach + Delete`. Two scope choices
+  keep teardown small and safe: vet **never creates/terminates the helper instance** (the operator
+  supplies a running, SSM-managed, syft-equipped instance), so vet only ever creates a *volume + an
+  attachment*; and vet **never touches the AMI's own backing snapshot** — it scans a fresh volume made
+  *from* it and deletes the copy. The volume lifecycle and the remote scan are separate seams
+  (`VolumeManager`, `RemoteScanner`) so the bug-prone part — **the volume is detached and deleted on
+  every failure path** (create-fails / attach-fails / scan-fails / detach-errors-but-delete-still-runs)
+  — is fully fake-tested without AWS. The thin live adapters (EC2 volume calls; SSM+S3 remote scan,
+  S3 because a full-AMI SBOM exceeds SSM's inline output cap) + live validation are the final slice.
+
 - **`internal/amiscan` — AMI content-scan orchestration** (provabl/vet#32, slice 3): an AMI's contents
   aren't directly scannable — you reach them through snapshot → volume → attach → mount → syft. This
   slice ships the **orchestration core** (resolve the AMI's backing EBS snapshot, drive the steps, and

--- a/internal/amiscan/ssm_mounter.go
+++ b/internal/amiscan/ssm_mounter.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package amiscan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// The live Mounter materialises a snapshot's filesystem on an operator-provided
+// helper instance and runs syft over it. The lifecycle is:
+//
+//	CreateVolume(from snapshot, in the helper's AZ) -> AttachVolume(to helper) ->
+//	remote: mount read-only + syft -> download SBOM -> [Release] Detach + Delete.
+//
+// Two deliberate scope choices keep teardown small and safe:
+//   - vet does NOT create or terminate the helper instance. The operator supplies a
+//     running, SSM-managed, syft-equipped instance (Config.InstanceID). So vet only
+//     ever creates a volume + an attachment — never an instance.
+//   - vet never touches the AMI's own backing snapshot; it creates a NEW volume
+//     FROM that snapshot, scans the copy, and deletes the copy.
+//
+// The volume lifecycle and the remote scan are separate seams so the bug-prone
+// part — guaranteeing the volume is detached and deleted on every path — is fully
+// fake-testable without AWS. The live adapters (EC2 + SSM/S3) are thin.
+
+// VolumeManager owns the EBS volume lifecycle for one scan.
+type VolumeManager interface {
+	// CreateFromSnapshot creates a volume from snapshotID in the given AZ and
+	// returns its id once it is available for attachment.
+	CreateFromSnapshot(ctx context.Context, snapshotID, az string) (volumeID string, err error)
+	// Attach attaches volumeID to instanceID at device (e.g. "/dev/sdf") and
+	// returns once attached.
+	Attach(ctx context.Context, volumeID, instanceID, device string) error
+	// Detach detaches volumeID and returns once detached.
+	Detach(ctx context.Context, volumeID string) error
+	// Delete deletes volumeID.
+	Delete(ctx context.Context, volumeID string) error
+}
+
+// RemoteScanner mounts an attached device on the helper instance read-only, runs
+// syft over its filesystem, and returns a LOCAL path to the downloaded SBOM. It
+// wraps SSM (run the commands) + S3 (ferry the SBOM back, since a full-AMI SBOM
+// exceeds SSM's inline output cap). It unmounts on its own; it does not own the
+// volume (the VolumeManager does).
+type RemoteScanner interface {
+	Scan(ctx context.Context, instanceID, device string) (sbomPath string, err error)
+}
+
+// Config is the operator-supplied context the live Mounter needs.
+type Config struct {
+	InstanceID string // a running, SSM-managed, syft-equipped helper instance
+	AZ         string // the helper instance's availability zone (volume must match)
+	Device     string // device name to attach at, e.g. "/dev/sdf"
+}
+
+// ssmMounter is the live Mounter: it composes a VolumeManager + a RemoteScanner.
+type ssmMounter struct {
+	vols VolumeManager
+	scan RemoteScanner
+	cfg  Config
+}
+
+// NewMounter builds a live Mounter from the volume + remote-scan seams and config.
+// Exposed with injectable seams so the lifecycle is testable; the production
+// wiring (EC2 VolumeManager + SSM/S3 RemoteScanner) is assembled by the caller.
+func NewMounter(vols VolumeManager, scan RemoteScanner, cfg Config) Mounter {
+	return &ssmMounter{vols: vols, scan: scan, cfg: cfg}
+}
+
+// Mount creates a volume from the snapshot, attaches it to the helper instance,
+// runs the remote scan, and returns a Mount whose Release detaches + deletes the
+// volume. Teardown is guaranteed on every failure path: if attach or the remote
+// scan fails after the volume exists, the volume is detached (best-effort) and
+// deleted before returning, so a failed scan never leaks an EBS volume.
+func (m *ssmMounter) Mount(ctx context.Context, snapshotID string) (*Mount, error) {
+	if m.cfg.InstanceID == "" || m.cfg.AZ == "" || m.cfg.Device == "" {
+		return nil, fmt.Errorf("mounter config incomplete: need InstanceID, AZ, and Device")
+	}
+
+	volID, err := m.vols.CreateFromSnapshot(ctx, snapshotID, m.cfg.AZ)
+	if err != nil {
+		return nil, fmt.Errorf("create volume from %s: %w", snapshotID, err)
+	}
+	// From here on, the volume exists — every error path must delete it.
+
+	if err := m.vols.Attach(ctx, volID, m.cfg.InstanceID, m.cfg.Device); err != nil {
+		// Not attached: just delete the volume.
+		m.cleanup(ctx, volID, false)
+		return nil, fmt.Errorf("attach volume %s to %s: %w", volID, m.cfg.InstanceID, err)
+	}
+
+	sbomPath, err := m.scan.Scan(ctx, m.cfg.InstanceID, m.cfg.Device)
+	if err != nil {
+		// Attached but scan failed: detach then delete.
+		m.cleanup(ctx, volID, true)
+		return nil, fmt.Errorf("remote scan of %s on %s: %w", volID, m.cfg.InstanceID, err)
+	}
+
+	return &Mount{
+		SBOMPath: sbomPath,
+		Release: func(ctx context.Context) error {
+			return m.cleanup(ctx, volID, true)
+		},
+	}, nil
+}
+
+// cleanup detaches (when attached) and deletes the volume. Both steps are attempted
+// even if one errors, so a detach failure cannot strand a deletable volume; the
+// combined error is returned for the caller to surface/log.
+func (m *ssmMounter) cleanup(ctx context.Context, volID string, attached bool) error {
+	var errs []error
+	if attached {
+		if err := m.vols.Detach(ctx, volID); err != nil {
+			errs = append(errs, fmt.Errorf("detach %s: %w", volID, err))
+		}
+	}
+	if err := m.vols.Delete(ctx, volID); err != nil {
+		errs = append(errs, fmt.Errorf("delete %s: %w", volID, err))
+	}
+	return errors.Join(errs...)
+}

--- a/internal/amiscan/ssm_mounter_test.go
+++ b/internal/amiscan/ssm_mounter_test.go
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package amiscan
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeVols records the volume lifecycle calls so tests can assert teardown
+// happened (and in the right order). Each step can be made to fail.
+type fakeVols struct {
+	createErr, attachErr, detachErr, deleteErr error
+	calls                                      []string
+}
+
+func (f *fakeVols) CreateFromSnapshot(_ context.Context, snap, az string) (string, error) {
+	f.calls = append(f.calls, "create")
+	if f.createErr != nil {
+		return "", f.createErr
+	}
+	return "vol-123", nil
+}
+func (f *fakeVols) Attach(_ context.Context, vol, inst, dev string) error {
+	f.calls = append(f.calls, "attach")
+	return f.attachErr
+}
+func (f *fakeVols) Detach(_ context.Context, vol string) error {
+	f.calls = append(f.calls, "detach")
+	return f.detachErr
+}
+func (f *fakeVols) Delete(_ context.Context, vol string) error {
+	f.calls = append(f.calls, "delete")
+	return f.deleteErr
+}
+
+type fakeScan struct {
+	path string
+	err  error
+}
+
+func (f fakeScan) Scan(context.Context, string, string) (string, error) {
+	return f.path, f.err
+}
+
+func goodCfg() Config { return Config{InstanceID: "i-helper", AZ: "us-east-1a", Device: "/dev/sdf"} }
+
+func TestMounter_HappyPathReleasesVolume(t *testing.T) {
+	vols := &fakeVols{}
+	m := NewMounter(vols, fakeScan{path: "/tmp/ami.sbom.json"}, goodCfg())
+
+	mount, err := m.Mount(context.Background(), "snap-1")
+	if err != nil {
+		t.Fatalf("Mount: %v", err)
+	}
+	if mount.SBOMPath != "/tmp/ami.sbom.json" {
+		t.Errorf("sbom path = %q", mount.SBOMPath)
+	}
+	// Volume created + attached; not yet torn down.
+	if got := strings.Join(vols.calls, ","); got != "create,attach" {
+		t.Fatalf("calls before release = %q, want create,attach", got)
+	}
+	if err := mount.Release(context.Background()); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if got := strings.Join(vols.calls, ","); got != "create,attach,detach,delete" {
+		t.Errorf("calls after release = %q, want create,attach,detach,delete", got)
+	}
+}
+
+func TestMounter_IncompleteConfigRejected(t *testing.T) {
+	m := NewMounter(&fakeVols{}, fakeScan{path: "/x"}, Config{InstanceID: "i-1"}) // missing AZ/Device
+	if _, err := m.Mount(context.Background(), "snap-1"); err == nil {
+		t.Error("expected an error for incomplete config")
+	}
+}
+
+// Create fails → no volume exists → nothing to tear down.
+func TestMounter_CreateFailsNoLeak(t *testing.T) {
+	vols := &fakeVols{createErr: errors.New("quota")}
+	m := NewMounter(vols, fakeScan{path: "/x"}, goodCfg())
+	if _, err := m.Mount(context.Background(), "snap-1"); err == nil {
+		t.Error("expected create error")
+	}
+	if got := strings.Join(vols.calls, ","); got != "create" {
+		t.Errorf("calls = %q, want create only (no volume to delete)", got)
+	}
+}
+
+// Attach fails → volume exists but is not attached → delete only (no detach).
+func TestMounter_AttachFailsDeletesVolume(t *testing.T) {
+	vols := &fakeVols{attachErr: errors.New("device busy")}
+	m := NewMounter(vols, fakeScan{path: "/x"}, goodCfg())
+	if _, err := m.Mount(context.Background(), "snap-1"); err == nil {
+		t.Error("expected attach error")
+	}
+	if got := strings.Join(vols.calls, ","); got != "create,attach,delete" {
+		t.Errorf("calls = %q, want create,attach,delete (no detach — never attached)", got)
+	}
+}
+
+// Scan fails after attach → must detach AND delete (no leak).
+func TestMounter_ScanFailsDetachesAndDeletes(t *testing.T) {
+	vols := &fakeVols{}
+	m := NewMounter(vols, fakeScan{err: errors.New("syft crashed")}, goodCfg())
+	if _, err := m.Mount(context.Background(), "snap-1"); err == nil {
+		t.Error("expected scan error")
+	}
+	if got := strings.Join(vols.calls, ","); got != "create,attach,detach,delete" {
+		t.Errorf("calls = %q, want create,attach,detach,delete", got)
+	}
+}
+
+// A detach error during cleanup must NOT prevent the delete — both are attempted.
+func TestMounter_DetachErrorStillDeletes(t *testing.T) {
+	vols := &fakeVols{detachErr: errors.New("still detaching")}
+	m := NewMounter(vols, fakeScan{err: errors.New("scan boom")}, goodCfg())
+	_, _ = m.Mount(context.Background(), "snap-1")
+	if got := strings.Join(vols.calls, ","); got != "create,attach,detach,delete" {
+		t.Errorf("calls = %q — delete must be attempted even when detach errors", got)
+	}
+}
+
+// End-to-end through the Scanner: an AMI -> backing snapshot -> live mounter,
+// confirming the orchestrator's release drives the volume teardown.
+func TestScanner_WithLiveMounter(t *testing.T) {
+	vols := &fakeVols{}
+	mounter := NewMounter(vols, fakeScan{path: "/tmp/s.json"}, goodCfg())
+	s := New(fakeInspector{snap: "snap-9"}, mounter)
+
+	path, release, err := s.Scan(context.Background(), "ami-0live")
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if path != "/tmp/s.json" {
+		t.Fatalf("unexpected sbom path: %q", path)
+	}
+	if release == nil {
+		t.Fatal("expected a non-nil release")
+	}
+	if err := release(context.Background()); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if got := strings.Join(vols.calls, ","); got != "create,attach,detach,delete" {
+		t.Errorf("full lifecycle = %q", got)
+	}
+}


### PR DESCRIPTION
Fourth slice of **vet#32**. The `Mounter` that materialises a backing snapshot into a scannable filesystem — shipping the **volume-lifecycle core with guaranteed teardown**, fully fake-tested. No AWS in CI.

## Lifecycle

`CreateVolume(from snapshot, in helper's AZ) → Attach(to helper) → remote mount read-only + syft → [Release] Detach + Delete`

## Two scope choices that keep teardown small and safe

- **vet never creates/terminates the helper instance.** The operator supplies a running, SSM-managed, syft-equipped instance (`Config.InstanceID/AZ/Device`). So vet only ever creates a **volume + an attachment** — never an instance. Much smaller teardown surface than spinning up a scanner box per AMI.
- **vet never touches the AMI's own backing snapshot.** It creates a *new* volume **from** that snapshot, scans the copy, and deletes the copy — the source AMI is untouched.

## What's tested (the bug-prone part)

The volume lifecycle (`VolumeManager`) and the remote scan (`RemoteScanner`) are separate seams so **guaranteed teardown on every failure path** is proven without AWS:

| Path | Teardown asserted |
|---|---|
| happy path | `create,attach` → Release → `detach,delete` |
| create fails | `create` only (no volume to delete) |
| attach fails | `create,attach,delete` (no detach — never attached) |
| scan fails | `create,attach,detach,delete` |
| detach errors | `delete` still attempted (errors joined, not short-circuited) |
| end-to-end Scanner+Mounter | full `create,attach,detach,delete` |

## Final slice

The thin live adapters: an EC2 `VolumeManager` (create/attach/detach/delete) and an SSM+S3 `RemoteScanner` (S3 because a full-AMI SBOM exceeds SSM's inline output cap), plus live validation against a real AMI with verified teardown. That slice creates real resources, so it lands with live validation — not in CI.

> Note: `gofmt` flags `internal/sign/sign.go` on the current toolchain — pre-existing drift, untouched here.