### PR TITLE
feat: live AWS adapters for AMI scanning (EC2 volumes + SSM/S3 syft) — vet#32 slice 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
+- **`amiscan` live AWS adapters — EC2 volumes + SSM/S3 remote syft** (provabl/vet#32, slice 5): the thin
+  adapters behind the slice-4 seams. `ec2Volumes` (`VolumeManager`) makes the EC2
+  `CreateVolume`(from snapshot, gp3, tagged `vet:ephemeral`) / `AttachVolume` / `DetachVolume` /
+  `DeleteVolume` calls, each waiting on the right state transition (available → in-use → available)
+  before the next step. `ssmScanner` (`RemoteScanner`) sends an `AWS-RunShellScript` that mounts the
+  attached device **read-only** (`-o ro`, so the scan can't mutate the evidence), runs syft to a
+  CycloneDX SBOM, and uploads it to an S3 staging bucket (S3 because a full-AMI SBOM exceeds SSM's
+  inline output cap), then downloads it locally; it polls the command to a terminal state and surfaces
+  remote stderr on failure. `amiscan.NewLive` assembles the whole live `Scanner` (inspector + volume
+  manager + remote scanner). Adds the SSM + S3 SDKs. SSM-scanner lifecycle is fake-tested
+  (success-downloads / remote-failure-surfaces-stderr / bucket-required / poll-timeout); the EC2 volume
+  calls are thin waiter wrappers. The CLI `vet verify ami-… --deep-scan` wiring + live validation are
+  the final slice.
+
 - **`amiscan` live Mounter — volume lifecycle with guaranteed teardown** (provabl/vet#32, slice 4):
   the `Mounter` impl that turns a backing snapshot into a scannable filesystem — `CreateVolume(from
   snapshot) → Attach(to helper) → remote mount + syft → [Release] Detach + Delete`. Two scope choices

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.307.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.54.4
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.0
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.69.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3
 	github.com/provabl/evidence v0.1.0
 	github.com/spf13/cobra v1.10.2
@@ -14,13 +16,16 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.24 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.29 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.2.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.31.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
 github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13 h1:p1BBrg/Hhp6uK7zpejeI8QFXHJeC/mynzi04Sl03k9g=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13/go.mod h1:8cIfkE9MDhkRZGpQ22aV6/lkYeYSozpz16Smrs5x4Ls=
 github.com/aws/aws-sdk-go-v2/config v1.32.25 h1:ACCejvStYoilgwrfegSt5ZntCbPrk52qfwyNcnl3omM=
 github.com/aws/aws-sdk-go-v2/config v1.32.25/go.mod h1:LJyU8sDRbXUxFn8xMJIGP+v9QYYwveNLI8a/giAOiAs=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.24 h1:2hQqYCV9yqyePQ9o6dCrZc/zO8U3TwPr9mIKlZnPu/I=
@@ -18,10 +20,18 @@ github.com/aws/aws-sdk-go-v2/service/iam v1.54.4 h1:V5Fl1MjjTCuC6PUsHOVWEbI5kMg0
 github.com/aws/aws-sdk-go-v2/service/iam v1.54.4/go.mod h1:tMNzI+fYFCk4cIdZ7FEybLzShwnmWkfxQw85ED1b4ng=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 h1:ZD2+BSw9vFsNlKYIasSNt3uDbjqqXIBcM13UJv/Lx2k=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12/go.mod h1:Ms4zlcVBbXbiP7EVLhl+lgjvA/a7YphqQ3Ih3174EmI=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.22 h1:V51LGlOq/1VsDsHUdoklAQi7rMmx4qQubvFYAlP2254=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.22/go.mod h1:4Pzhyz8hJOm2bepgl+NjvRx8vlUFAIIvJnZ/MkcNPpU=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29 h1:DRebniUGZ2MqiiIVmQJ04vIXr918hubdHMnarSLEWyU=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29/go.mod h1:LfRkPCD8YHDM2E5eTkos2UpwYeZnBcVarTa8L59bJHA=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.29 h1:hiME6pBzC7OTl9LMtlyTWBuEl1f4QBcUmFDKC7MLXtc=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.29/go.mod h1:G7RP+uhagpKtKhd1BM9N6JQqjCcGEU47K5lBVZQyRQw=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.104.0 h1:ta8csKy5vN91F3i5gGR85lFV0srBqySEji7Jroes6rE=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.104.0/go.mod h1:77ZAgynvx1txMvDG8gGWoWkO1augYDxkp9JElWFgjQU=
 github.com/aws/aws-sdk-go-v2/service/signin v1.2.0 h1:3nXpRcFwRCW8n7HgO2QGy0Dc20eQNfBuUemGQhpF8m8=
 github.com/aws/aws-sdk-go-v2/service/signin v1.2.0/go.mod h1:LxYujSTLPRlp2vTtcUO/+1ilrew8ytt6SvQyOgejzFQ=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.69.3 h1:58LjP8cp8UEHA1LG/JZ4fG9SobHE82kLYe46mogbSI4=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.69.3/go.mod h1:16Zd02ocSJp68o4r36MQ4Rikf/Ulv4On5qjMpJJf5Mo=
 github.com/aws/aws-sdk-go-v2/service/sso v1.31.3 h1:ey1XLTYXb9PcLt4535632o5kCGXNXEhNb620Dqwuylo=
 github.com/aws/aws-sdk-go-v2/service/sso v1.31.3/go.mod h1:Lk7PlmoTYryQmyBG0EXqj5BcUbj3whXdU2s3yGI3EAc=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.6 h1:yLr03zQE/5Eu5l3QU0Si+xMbLMbSDF2YXsigqXngs6g=

--- a/internal/amiscan/amiscan.go
+++ b/internal/amiscan/amiscan.go
@@ -65,6 +65,27 @@ func New(inspector ImageInspector, mounter Mounter) *Scanner {
 	return &Scanner{inspector: inspector, mounter: mounter}
 }
 
+// NewLive assembles a Scanner wired to AWS: a read-only EC2 inspector and a live
+// Mounter (EC2 volume lifecycle + SSM/S3 remote syft). cfg names the
+// operator-provided helper instance; bucket is the S3 SBOM staging bucket;
+// localDir is where the SBOM lands. This is the production constructor the CLI's
+// deep-scan path uses; the seam-based New stays for tests and custom wiring.
+func NewLive(ctx context.Context, region, bucket, localDir string, cfg Config) (*Scanner, error) {
+	inspector, err := NewEC2Inspector(ctx, region)
+	if err != nil {
+		return nil, err
+	}
+	vols, err := NewEC2VolumeManager(ctx, region)
+	if err != nil {
+		return nil, err
+	}
+	scanner, err := NewSSMScanner(ctx, region, bucket, localDir)
+	if err != nil {
+		return nil, err
+	}
+	return New(inspector, NewMounter(vols, scanner, cfg)), nil
+}
+
 // Scan resolves the AMI's backing snapshot, mounts it, and returns the path to
 // the SBOM syft produced — for a cve.Source to scan. The returned release tears
 // down everything created for the scan; the caller MUST call it (typically

--- a/internal/amiscan/ec2_volumes.go
+++ b/internal/amiscan/ec2_volumes.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package amiscan
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// ec2VolumeAPI is the subset of the EC2 client the VolumeManager needs (mockable).
+type ec2VolumeAPI interface {
+	CreateVolume(ctx context.Context, in *ec2.CreateVolumeInput, optFns ...func(*ec2.Options)) (*ec2.CreateVolumeOutput, error)
+	AttachVolume(ctx context.Context, in *ec2.AttachVolumeInput, optFns ...func(*ec2.Options)) (*ec2.AttachVolumeOutput, error)
+	DetachVolume(ctx context.Context, in *ec2.DetachVolumeInput, optFns ...func(*ec2.Options)) (*ec2.DetachVolumeOutput, error)
+	DeleteVolume(ctx context.Context, in *ec2.DeleteVolumeInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVolumeOutput, error)
+	ec2.DescribeVolumesAPIClient
+}
+
+// ec2Volumes is the live VolumeManager: thin wrappers over the EC2 volume calls,
+// each waiting for the resource to reach the state the next step needs. The
+// lifecycle orchestration + guaranteed teardown lives in the Mounter (slice 4,
+// fake-tested); this adapter only makes the calls.
+type ec2Volumes struct {
+	client ec2VolumeAPI
+	// waitTimeout bounds each state transition wait.
+	waitTimeout time.Duration
+}
+
+// NewEC2VolumeManager builds a VolumeManager backed by the AWS EC2 client. The
+// scan volumes it creates are tagged ephemeral so a stray one is easy to find.
+func NewEC2VolumeManager(ctx context.Context, region string) (VolumeManager, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("load AWS config: %w", err)
+	}
+	return &ec2Volumes{client: ec2.NewFromConfig(cfg), waitTimeout: 3 * time.Minute}, nil
+}
+
+// CreateFromSnapshot creates a volume from the snapshot in az and waits until it
+// is available. The volume is tagged so it is identifiable as a vet scan artifact.
+func (v *ec2Volumes) CreateFromSnapshot(ctx context.Context, snapshotID, az string) (string, error) {
+	out, err := v.client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		SnapshotId:       aws.String(snapshotID),
+		AvailabilityZone: aws.String(az),
+		VolumeType:       ec2types.VolumeTypeGp3,
+		TagSpecifications: []ec2types.TagSpecification{{
+			ResourceType: ec2types.ResourceTypeVolume,
+			Tags: []ec2types.Tag{
+				{Key: aws.String("Name"), Value: aws.String("vet-ami-scan")},
+				{Key: aws.String("vet:ephemeral"), Value: aws.String("true")},
+				{Key: aws.String("vet:purpose"), Value: aws.String("ami-content-scan")},
+			},
+		}},
+	})
+	if err != nil {
+		return "", err
+	}
+	volID := aws.ToString(out.VolumeId)
+	w := ec2.NewVolumeAvailableWaiter(v.client)
+	if err := w.Wait(ctx, &ec2.DescribeVolumesInput{VolumeIds: []string{volID}}, v.waitTimeout); err != nil {
+		return volID, fmt.Errorf("waiting for volume %s to become available: %w", volID, err)
+	}
+	return volID, nil
+}
+
+// Attach attaches the volume to the instance at device and waits until in-use.
+func (v *ec2Volumes) Attach(ctx context.Context, volumeID, instanceID, device string) error {
+	_, err := v.client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId:   aws.String(volumeID),
+		InstanceId: aws.String(instanceID),
+		Device:     aws.String(device),
+	})
+	if err != nil {
+		return err
+	}
+	w := ec2.NewVolumeInUseWaiter(v.client)
+	if err := w.Wait(ctx, &ec2.DescribeVolumesInput{VolumeIds: []string{volumeID}}, v.waitTimeout); err != nil {
+		return fmt.Errorf("waiting for volume %s to attach: %w", volumeID, err)
+	}
+	return nil
+}
+
+// Detach detaches the volume and waits until it is available again (a volume
+// cannot be deleted while still attaching/detaching).
+func (v *ec2Volumes) Detach(ctx context.Context, volumeID string) error {
+	_, err := v.client.DetachVolume(ctx, &ec2.DetachVolumeInput{VolumeId: aws.String(volumeID)})
+	if err != nil {
+		return err
+	}
+	w := ec2.NewVolumeAvailableWaiter(v.client)
+	if err := w.Wait(ctx, &ec2.DescribeVolumesInput{VolumeIds: []string{volumeID}}, v.waitTimeout); err != nil {
+		return fmt.Errorf("waiting for volume %s to detach: %w", volumeID, err)
+	}
+	return nil
+}
+
+// Delete deletes the volume.
+func (v *ec2Volumes) Delete(ctx context.Context, volumeID string) error {
+	_, err := v.client.DeleteVolume(ctx, &ec2.DeleteVolumeInput{VolumeId: aws.String(volumeID)})
+	return err
+}

--- a/internal/amiscan/ssm_scanner.go
+++ b/internal/amiscan/ssm_scanner.go
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package amiscan
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+// ssmAPI / s3API are the client subsets the remote scanner needs (mockable).
+type ssmAPI interface {
+	SendCommand(ctx context.Context, in *ssm.SendCommandInput, optFns ...func(*ssm.Options)) (*ssm.SendCommandOutput, error)
+	GetCommandInvocation(ctx context.Context, in *ssm.GetCommandInvocationInput, optFns ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error)
+}
+
+type s3Getter interface {
+	GetObject(ctx context.Context, in *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+}
+
+// ssmScanner mounts the attached device on the helper instance read-only, runs
+// syft over its root filesystem, uploads the SBOM to S3 (because a full-AMI SBOM
+// exceeds SSM's ~24 KB inline output cap), and downloads it locally. It assumes
+// the helper has syft and the AWS CLI on PATH and an instance profile that can
+// PutObject to the staging bucket — documented as the operator's responsibility
+// (the same managed/equipped helper slice 4's Config requires).
+type ssmScanner struct {
+	ssm      ssmAPI
+	s3       s3Getter
+	bucket   string        // S3 staging bucket for the SBOM hand-off
+	localDir string        // where the downloaded SBOM is written
+	poll     time.Duration // command-completion poll interval
+	pollMax  int           // max polls before giving up
+}
+
+// NewSSMScanner builds a RemoteScanner. bucket is an S3 bucket both the helper
+// (PutObject) and this process (GetObject) can reach; localDir is where the SBOM
+// lands (e.g. the .vet store dir).
+func NewSSMScanner(ctx context.Context, region, bucket, localDir string) (RemoteScanner, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("load AWS config: %w", err)
+	}
+	return &ssmScanner{
+		ssm:      ssm.NewFromConfig(cfg),
+		s3:       s3.NewFromConfig(cfg),
+		bucket:   bucket,
+		localDir: localDir,
+		poll:     5 * time.Second,
+		pollMax:  60, // ~5 min
+	}, nil
+}
+
+// remoteScript mounts the device read-only, syfts it, and uploads the SBOM to S3.
+// It is deliberately defensive: mount read-only (-o ro) so the scan can never
+// mutate the evidence, and always attempt an unmount. {{DEVICE}}/{{KEY}} are
+// substituted; the bucket is passed via the script for a single self-contained
+// command document.
+const remoteScript = `set -euo pipefail
+DEV="%s"
+BUCKET="%s"
+KEY="%s"
+MNT="$(mktemp -d)"
+cleanup() { umount "$MNT" 2>/dev/null || true; rmdir "$MNT" 2>/dev/null || true; }
+trap cleanup EXIT
+# The attached snapshot's root partition: try the whole device, then partition 1.
+mount -o ro "$DEV" "$MNT" 2>/dev/null || mount -o ro "${DEV}1" "$MNT" 2>/dev/null || mount -o ro "${DEV}p1" "$MNT"
+syft scan "dir:$MNT" -o cyclonedx-json --file /tmp/ami-sbom.json --quiet
+aws s3 cp /tmp/ami-sbom.json "s3://$BUCKET/$KEY" --only-show-errors
+`
+
+// Scan runs the remote mount+syft, then downloads the produced SBOM. The S3 key
+// is derived from the instance + a fixed suffix; the caller's localDir holds the
+// result. Returns the local SBOM path.
+func (s *ssmScanner) Scan(ctx context.Context, instanceID, device string) (string, error) {
+	if s.bucket == "" {
+		return "", fmt.Errorf("ssm scanner requires an S3 staging bucket")
+	}
+	key := fmt.Sprintf("vet-ami-scan/%s.cyclonedx.json", instanceID)
+	script := fmt.Sprintf(remoteScript, device, s.bucket, key)
+
+	out, err := s.ssm.SendCommand(ctx, &ssm.SendCommandInput{
+		InstanceIds:  []string{instanceID},
+		DocumentName: aws.String("AWS-RunShellScript"),
+		Parameters:   map[string][]string{"commands": {script}},
+	})
+	if err != nil {
+		return "", fmt.Errorf("ssm send-command: %w", err)
+	}
+	cmdID := aws.ToString(out.Command.CommandId)
+
+	if err := s.waitForCommand(ctx, cmdID, instanceID); err != nil {
+		return "", err
+	}
+
+	localPath := s.localDir + "/ami-scan.cyclonedx.json"
+	if err := s.download(ctx, key, localPath); err != nil {
+		return "", fmt.Errorf("download SBOM from s3://%s/%s: %w", s.bucket, key, err)
+	}
+	return localPath, nil
+}
+
+// waitForCommand polls until the SSM command reaches a terminal state, returning
+// an error (with the captured stderr) on anything but Success.
+func (s *ssmScanner) waitForCommand(ctx context.Context, cmdID, instanceID string) error {
+	for i := 0; i < s.pollMax; i++ {
+		inv, err := s.ssm.GetCommandInvocation(ctx, &ssm.GetCommandInvocationInput{
+			CommandId:  aws.String(cmdID),
+			InstanceId: aws.String(instanceID),
+		})
+		if err != nil {
+			// The invocation can briefly 404 right after SendCommand; tolerate it.
+			if strings.Contains(err.Error(), "InvocationDoesNotExist") {
+				if !sleep(ctx, s.poll) {
+					return ctx.Err()
+				}
+				continue
+			}
+			return fmt.Errorf("ssm get-command-invocation: %w", err)
+		}
+		switch inv.Status {
+		case ssmtypes.CommandInvocationStatusSuccess:
+			return nil
+		case ssmtypes.CommandInvocationStatusCancelled,
+			ssmtypes.CommandInvocationStatusTimedOut,
+			ssmtypes.CommandInvocationStatusFailed:
+			return fmt.Errorf("remote scan %s on %s: %s\n%s",
+				cmdID, instanceID, inv.Status, sanitizeOut(aws.ToString(inv.StandardErrorContent)))
+		}
+		if !sleep(ctx, s.poll) {
+			return ctx.Err()
+		}
+	}
+	return fmt.Errorf("remote scan %s did not complete within the poll window", cmdID)
+}
+
+// download fetches the S3 object to localPath.
+func (s *ssmScanner) download(ctx context.Context, key, localPath string) error {
+	obj, err := s.s3.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = obj.Body.Close() }()
+	f, err := os.Create(localPath) // #nosec G304 — store-derived path
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	_, err = io.Copy(f, obj.Body)
+	return err
+}
+
+// sleep waits d or until ctx is done; returns false if the context ended.
+func sleep(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+// sanitizeOut strips control characters and bounds remote stderr before it goes
+// into an error message.
+func sanitizeOut(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r >= 0x20 || r == '\n' || r == '\t' {
+			b.WriteRune(r)
+		}
+	}
+	out := b.String()
+	const max = 2000
+	if len(out) > max {
+		return out[:max] + "…(truncated)"
+	}
+	return out
+}

--- a/internal/amiscan/ssm_scanner_test.go
+++ b/internal/amiscan/ssm_scanner_test.go
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2026 Playground Logic LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package amiscan
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+// fakeSSM scripts a SendCommand id and a sequence of GetCommandInvocation results.
+type fakeSSM struct {
+	sentScript string
+	statuses   []ssmtypes.CommandInvocationStatus // consumed one per poll
+	stderr     string
+	idx        int
+}
+
+func (f *fakeSSM) SendCommand(_ context.Context, in *ssm.SendCommandInput, _ ...func(*ssm.Options)) (*ssm.SendCommandOutput, error) {
+	if cmds := in.Parameters["commands"]; len(cmds) > 0 {
+		f.sentScript = cmds[0]
+	}
+	return &ssm.SendCommandOutput{Command: &ssmtypes.Command{CommandId: aws.String("cmd-1")}}, nil
+}
+
+func (f *fakeSSM) GetCommandInvocation(_ context.Context, _ *ssm.GetCommandInvocationInput, _ ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error) {
+	st := f.statuses[f.idx]
+	if f.idx < len(f.statuses)-1 {
+		f.idx++
+	}
+	return &ssm.GetCommandInvocationOutput{Status: st, StandardErrorContent: aws.String(f.stderr)}, nil
+}
+
+// fakeS3 returns canned object bytes.
+type fakeS3 struct {
+	body   string
+	gotKey string
+	getErr error
+}
+
+func (f *fakeS3) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	f.gotKey = aws.ToString(in.Key)
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return &s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader(f.body))}, nil
+}
+
+func newScanner(t *testing.T, ss ssmAPI, s3c s3Getter) *ssmScanner {
+	t.Helper()
+	return &ssmScanner{
+		ssm: ss, s3: s3c,
+		bucket: "stage-bucket", localDir: t.TempDir(),
+		poll: time.Millisecond, pollMax: 10,
+	}
+}
+
+func TestScanner_SuccessDownloadsSBOM(t *testing.T) {
+	ss := &fakeSSM{statuses: []ssmtypes.CommandInvocationStatus{
+		ssmtypes.CommandInvocationStatusInProgress,
+		ssmtypes.CommandInvocationStatusSuccess,
+	}}
+	s3c := &fakeS3{body: `{"bomFormat":"CycloneDX"}`}
+	sc := newScanner(t, ss, s3c)
+
+	path, err := sc.Scan(context.Background(), "i-helper", "/dev/sdf")
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	// The remote script must mount read-only and target the attached device.
+	if !strings.Contains(ss.sentScript, "mount -o ro") || !strings.Contains(ss.sentScript, "/dev/sdf") {
+		t.Errorf("script missing read-only mount of the device:\n%s", ss.sentScript)
+	}
+	if !strings.Contains(ss.sentScript, "syft scan") {
+		t.Errorf("script does not run syft:\n%s", ss.sentScript)
+	}
+	// S3 key is instance-scoped; the SBOM is downloaded locally.
+	if !strings.Contains(s3c.gotKey, "i-helper") {
+		t.Errorf("S3 key = %q, want it to include the instance id", s3c.gotKey)
+	}
+	if b, _ := readFile(path); !strings.Contains(b, "CycloneDX") {
+		t.Errorf("downloaded SBOM not written to %s", path)
+	}
+}
+
+func TestScanner_RemoteFailureSurfacesStderr(t *testing.T) {
+	ss := &fakeSSM{
+		statuses: []ssmtypes.CommandInvocationStatus{ssmtypes.CommandInvocationStatusFailed},
+		stderr:   "mount: wrong fs type",
+	}
+	sc := newScanner(t, ss, &fakeS3{})
+	_, err := sc.Scan(context.Background(), "i-helper", "/dev/sdf")
+	if err == nil || !strings.Contains(err.Error(), "wrong fs type") {
+		t.Fatalf("expected remote stderr in the error, got %v", err)
+	}
+}
+
+func TestScanner_RequiresBucket(t *testing.T) {
+	sc := &ssmScanner{ssm: &fakeSSM{}, s3: &fakeS3{}, poll: time.Millisecond, pollMax: 1}
+	if _, err := sc.Scan(context.Background(), "i-helper", "/dev/sdf"); err == nil {
+		t.Error("expected an error when no staging bucket is configured")
+	}
+}
+
+func TestScanner_TimesOut(t *testing.T) {
+	ss := &fakeSSM{statuses: []ssmtypes.CommandInvocationStatus{ssmtypes.CommandInvocationStatusInProgress}}
+	sc := newScanner(t, ss, &fakeS3{})
+	sc.pollMax = 3
+	_, err := sc.Scan(context.Background(), "i-helper", "/dev/sdf")
+	if err == nil || !strings.Contains(err.Error(), "did not complete") {
+		t.Fatalf("expected a poll-window timeout, got %v", err)
+	}
+}
+
+func readFile(p string) (string, error) {
+	b, err := os.ReadFile(p) //nolint:gosec // test path
+	return string(b), err
+}


### PR DESCRIPTION
Fifth slice of **vet#32**. The thin live AWS adapters behind the slice-4 `Mounter` seams. No AWS in CI (the adapters' testable logic is faked; live validation is the final slice).

## What

- **`ec2Volumes` (`VolumeManager`)** — the EC2 volume lifecycle: `CreateVolume`(from snapshot, gp3, tagged `vet:ephemeral`) → `AttachVolume` → `DetachVolume` → `DeleteVolume`, each **waiting on the right state transition** (available → in-use → available) before the next step, so e.g. a delete never races an in-progress detach.
- **`ssmScanner` (`RemoteScanner`)** — sends an `AWS-RunShellScript` that mounts the attached device **read-only** (`-o ro` — the scan can't mutate the evidence), runs syft → CycloneDX, and uploads to an **S3 staging bucket** (S3 because a full-AMI SBOM exceeds SSM's ~24 KB inline output cap). It polls the command to a terminal state, **surfaces remote stderr on failure**, and downloads the SBOM locally.
- **`amiscan.NewLive`** — assembles the full live `Scanner` (inspector + volume manager + remote scanner) from region + bucket + helper config; the seam-based `New` stays for tests.
- Adds the SSM + S3 SDKs.

## Tests

The bug-prone parts are already proven: the volume-teardown lifecycle (slice 4) and snapshot resolution (slice 3) are fake-tested. This slice's own testable logic — the SSM command lifecycle — is faked here:
- success → downloads the SBOM; script mounts read-only + targets the device + runs syft; S3 key is instance-scoped
- remote failure → surfaces the remote stderr
- no staging bucket → error
- never completes → poll-window timeout

The EC2 volume calls are thin AWS-waiter wrappers (exercised live in the final slice).

## Final slice

The CLI surface: `vet verify ami-… --deep-scan --helper-instance i-… --scan-bucket …` wires `amiscan.NewLive` → SBOM → the grype `cve.Source` end to end, plus **live validation against a real AMI with verified teardown** (the discipline used for the Inspector test). That slice creates real resources, so it's done as a live session, not in CI.

> Note: `gofmt` flags `internal/sign/sign.go` on the current toolchain — pre-existing drift, untouched here.